### PR TITLE
Fix showing resource data for instances

### DIFF
--- a/src/api/metrics.tsx
+++ b/src/api/metrics.tsx
@@ -1,5 +1,7 @@
 import parsePrometheusTextFormat from "parse-prometheus-text-format";
 import { LxdMetricGroup } from "types/metrics";
+import { handleEtagResponse } from "util/helpers";
+import { LxdInstanceState } from "types/instance";
 
 export const fetchMetrics = (): Promise<LxdMetricGroup[]> => {
   return new Promise((resolve, reject) => {
@@ -11,6 +13,18 @@ export const fetchMetrics = (): Promise<LxdMetricGroup[]> => {
         const json = parsePrometheusTextFormat(text);
         resolve(json);
       })
+      .catch(reject);
+  });
+};
+
+export const fetchInstanceState = (
+  name: string,
+  project: string,
+): Promise<LxdInstanceState> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/instances/${name}/state?project=${project}`)
+      .then(handleEtagResponse)
+      .then((data) => resolve(data as LxdInstanceState))
       .catch(reject);
   });
 };

--- a/src/types/instance.d.ts
+++ b/src/types/instance.d.ts
@@ -1,8 +1,13 @@
 import { LxdConfigPair } from "./config";
 import { LxdDevices } from "./device";
 
-interface LxdInstanceUsageProp {
+interface LxdInstanceCPUUsage {
   usage: number;
+}
+
+interface LxdInstanceDiskUsage {
+  usage: number;
+  total: number;
 }
 
 interface LxdInstanceMemory {
@@ -41,10 +46,10 @@ interface LxdInstanceNetwork {
 }
 
 interface LxdInstanceState {
-  cpu: LxdInstanceUsageProp;
+  cpu: LxdInstanceCPUUsage;
   disk: {
-    root: LxdInstanceUsageProp;
-  } & Record<string, LxdInstanceUsageProp>;
+    root: LxdInstanceDiskUsage;
+  } & Record<string, LxdInstanceDiskUsage>;
   memory: LxdInstanceMemory;
   network?: Record<string, LxdInstanceNetwork>;
   pid: number;

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -121,6 +121,14 @@ export const humanFileSize = (bytes: number): string => {
   return `${bytes.toFixed(1)} ${units[u]}`;
 };
 
+export const humanCpuUsage = (nseconds: number): string => {
+  if (nseconds <= 0) {
+    return "-";
+  }
+
+  return (nseconds/1000000000).toFixed(2);
+};
+
 export const getWsProtocol = (): string => {
     if (window.location.protocol === 'https:') {
         return "wss";


### PR DESCRIPTION
1. Use `/1.0/instances/{name}/state` data instead of `/1.0/metrics` endpoint for fetching usage data.
2. Add CPU usage to usage view.