### PR TITLE
Add instance preview to overview view

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -1,5 +1,6 @@
 import {
   continueOrFinish,
+  handleBlobResponse,
   handleEtagResponse,
   handleResponse,
   handleTextResponse,
@@ -393,6 +394,15 @@ export const createInstanceBackup = (
     })
       .then(handleResponse)
       .then((data: LxdOperationResponse) => resolve(data))
+      .catch(reject);
+  });
+};
+
+export const fetchInstancePreview = (instance: LxdInstance): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/instances/${instance.name}/console?project=${instance.project}&type=vga`)
+      .then(handleBlobResponse)
+      .then((data) => resolve(URL.createObjectURL(data)))
       .catch(reject);
   });
 };

--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -7,6 +7,7 @@ import useEventListener from "@use-it/event-listener";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import InstanceOverviewProfiles from "./InstanceOverviewProfiles";
 import InstanceOverviewMetrics from "./InstanceOverviewMetrics";
+import InstancePreview from "./InstancePreview";
 import InstanceIps from "pages/instances/InstanceIps";
 import { useSettings } from "context/useSettings";
 import NotificationRow from "components/NotificationRow";
@@ -117,6 +118,16 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
               </tr>
             </tbody>
           </table>
+        </Col>
+      </Row>
+      <Row className="instance-preview">
+        <Col size={3}>
+          <h2 className="p-heading--5">Preview</h2>
+        </Col>
+        <Col size={4}>
+          <InstancePreview instance={instance} onFailure={onFailure}/>
+        </Col>
+        <Col size={3}>
         </Col>
       </Row>
       <Row className="usage">

--- a/src/pages/instances/InstancePreview.tsx
+++ b/src/pages/instances/InstancePreview.tsx
@@ -1,0 +1,36 @@
+import { FC } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchInstancePreview } from "api/instances";
+import Loader from "components/Loader";
+import { LxdInstance } from "types/instance";
+
+interface Props {
+    instance: LxdInstance;
+    onFailure: (title: string, e: unknown) => void;
+}
+
+const InstancePreview: FC<Props> = ({ instance, onFailure }) => {
+
+    const {
+    data: imgData,
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: [queryKeys.instancePreview, instance.project, instance.name],
+    queryFn: () => fetchInstancePreview(instance),
+    staleTime: 10 * 1000, // 10s
+  });
+
+  return (
+    <>
+      {isLoading ? (
+        <Loader text="Loading instance preview..." />
+      ) : (
+        <img src={imgData} />
+      )}
+    </>
+  );
+};
+
+export default InstancePreview;

--- a/src/sass/_instance_detail_overview.scss
+++ b/src/sass/_instance_detail_overview.scss
@@ -11,6 +11,7 @@
   }
 
   .general,
+  .instance-preview,
   .usage,
   .networks {
     border-bottom: 1px solid $color-mid-light;
@@ -21,6 +22,7 @@
   }
 
   .general,
+  .instance-preview,
   .usage {
     tr {
       border: none;

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -102,6 +102,15 @@ export const handleTextResponse = async (
   return response.text();
 };
 
+export const handleBlobResponse = async (response: Response) => {
+  if (!response.ok) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const result: ErrorResponse = await response.json();
+    throw Error(result.error);
+  }
+  return response.blob();
+};
+
 export const humanFileSize = (bytes: number): string => {
   if (Math.abs(bytes) < 1000) {
     return `${bytes} B`;

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -26,4 +26,5 @@ export const queryKeys = {
   authGroups: "authGroups",
   idpGroups: "idpGroups",
   permissions: "permissions",
+  instancePreview: "instancePreview",
 };


### PR DESCRIPTION
This PR adds an instance preview to the instance details view. A custom `InstancePreview` component was created to provide greater control over image rendering. For example, the image is downloaded from the server at most once every 10 seconds, which prevents it from being re-downloaded each time the user navigates to the `Overview` tab.

## Screenshots

![preview](https://github.com/user-attachments/assets/87f2b936-7259-463e-9f16-2d8dcb077ecf)
