### PR TITLE
Support for special disks devices

### DIFF
--- a/src/components/forms/DiskDeviceForm.tsx
+++ b/src/components/forms/DiskDeviceForm.tsx
@@ -10,6 +10,7 @@ import { getInheritedVolumes } from "util/configInheritance";
 import DiskDeviceFormRoot from "./DiskDeviceFormRoot";
 import DiskDeviceFormInherited from "./DiskDeviceFormInherited";
 import DiskDeviceFormCustom from "./DiskDeviceFormCustom";
+import DiskDeviceFormSpecial from "./DiskDeviceFormSpecial";
 import classnames from "classnames";
 import ScrollableForm from "components/ScrollableForm";
 
@@ -29,6 +30,8 @@ const DiskDeviceForm: FC<Props> = ({ formik, project }) => {
     queryKey: [queryKeys.profiles],
     queryFn: () => fetchProfiles(project),
   });
+
+  const showSpecialDisk = (formik.values.entityType == "instance" && formik.values.instanceType == "virtual-machine") || formik.values.entityType == "profile" ? true : false;
 
   if (profileError) {
     notify.failure("Loading profiles failed", profileError);
@@ -67,6 +70,11 @@ const DiskDeviceForm: FC<Props> = ({ formik, project }) => {
           formik={formik}
           inheritedVolumes={inheritedVolumes}
         />
+        {showSpecialDisk && (<DiskDeviceFormSpecial
+          formik={formik}
+          project={project}
+          profiles={profiles}
+        />)}
         <DiskDeviceFormCustom
           formik={formik}
           project={project}

--- a/src/components/forms/DiskDeviceFormCustom.tsx
+++ b/src/components/forms/DiskDeviceFormCustom.tsx
@@ -18,6 +18,7 @@ import { LxdStorageVolume } from "types/storage";
 import {
   isDiskDeviceMountPointMissing,
   isRootDisk,
+  isSpecialDisk,
 } from "util/instanceValidation";
 import { ensureEditMode } from "util/instanceEdit";
 import { getExistingDeviceNames } from "util/devices";
@@ -33,7 +34,7 @@ interface Props {
 const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
   const readOnly = (formik.values as EditInstanceFormValues).readOnly;
   const customVolumes = formik.values.devices
-    .filter((item) => item.type === "disk" && !isRootDisk(item))
+    .filter((item) => item.type === "disk" && !isRootDisk(item) && !isSpecialDisk(item))
     .map((device) => device as FormDiskDevice);
 
   const existingDeviceNames = getExistingDeviceNames(formik.values, profiles);

--- a/src/components/forms/DiskDeviceFormInherited.tsx
+++ b/src/components/forms/DiskDeviceFormInherited.tsx
@@ -15,6 +15,7 @@ import {
 import DetachDiskDeviceBtn from "pages/instances/actions/DetachDiskDeviceBtn";
 import { getInheritedDeviceRow } from "components/forms/InheritedDeviceRow";
 import { ensureEditMode } from "util/instanceEdit";
+import { isSpecialDisk } from "util/instanceValidation";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -71,27 +72,41 @@ const DiskDeviceFormInherited: FC<Props> = ({ formik, inheritedVolumes }) => {
       }),
     );
 
-    rows.push(
-      getInheritedDeviceRow({
-        label: "Pool / volume",
-        inheritValue: (
-          <>
-            {item.disk.pool} / {item.disk.source}
-          </>
-        ),
-        readOnly: readOnly,
-        isDeactivated: isNoneDevice,
-      }),
-    );
+    if (isSpecialDisk(item.disk)) {
+      rows.push(
+        getInheritedDeviceRow({
+          label: "Source",
+          inheritValue: (
+            <>
+              {item.disk.source}
+            </>
+          ),
+          readOnly: readOnly,
+        }),
+      );
+    } else {
+      rows.push(
+        getInheritedDeviceRow({
+          label: "Pool / volume",
+          inheritValue: (
+            <>
+              {item.disk.pool} / {item.disk.source}
+            </>
+          ),
+          readOnly: readOnly,
+          isDeactivated: isNoneDevice,
+        }),
+      );
 
-    rows.push(
-      getInheritedDeviceRow({
-        label: "Mount point",
-        inheritValue: item.disk.path,
-        readOnly: readOnly,
-        isDeactivated: isNoneDevice,
-      }),
-    );
+      rows.push(
+        getInheritedDeviceRow({
+          label: "Mount point",
+          inheritValue: item.disk.path,
+          readOnly: readOnly,
+          isDeactivated: isNoneDevice,
+        }),
+      );
+    }
   });
 
   return inheritedVolumes.length > 0 ? (

--- a/src/components/forms/DiskDeviceFormSpecial.tsx
+++ b/src/components/forms/DiskDeviceFormSpecial.tsx
@@ -1,0 +1,135 @@
+import { FC } from "react";
+import { Button, Icon, Label, Select } from "@canonical/react-components";
+import { InstanceAndProfileFormikProps } from "./instanceAndProfileFormValues";
+import { EditInstanceFormValues } from "pages/instances/EditInstance";
+import {
+  deduplicateName,
+  FormDiskDevice,
+  removeDevice,
+} from "util/formDevices";
+import RenameDeviceInput from "./RenameDeviceInput";
+import ConfigurationTable from "components/ConfigurationTable";
+import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import { getConfigurationRowBase } from "components/ConfigurationRow";
+import DetachDiskDeviceBtn from "pages/instances/actions/DetachDiskDeviceBtn";
+import { isRootDisk, isSpecialDisk } from "util/instanceValidation";
+import { ensureEditMode } from "util/instanceEdit";
+import { getExistingDeviceNames } from "util/devices";
+import { LxdProfile } from "types/profile";
+
+interface Props {
+  formik: InstanceAndProfileFormikProps;
+  project: string;
+  profiles: LxdProfile[];
+}
+
+const DiskDeviceFormSpecial: FC<Props> = ({ formik, project, profiles }) => {
+  const readOnly = (formik.values as EditInstanceFormValues).readOnly;
+  const specialDisks = formik.values.devices
+    .filter((item) => item.type === "disk" && isSpecialDisk(item) && !isRootDisk(item))
+    .map((device) => device as FormDiskDevice);
+
+  const existingDeviceNames = getExistingDeviceNames(formik.values, profiles);
+
+  const getSourceOptions = () => {
+    const options = [{
+      label: "cloud-init:config",
+      value: "cloud-init:config",
+    }, {
+      label: "agent:config",
+      value: "agent:config",
+    }];
+    return options;
+  };
+
+  const addSpecialDisk = () => {
+    const copy = [...formik.values.devices];
+    copy.push({
+      type: "disk",
+      name: deduplicateName("config", 1, existingDeviceNames),
+      source: "cloud-init:config",
+    });
+    void formik.setFieldValue("devices", copy);
+  };
+
+  const rows: MainTableRow[] = [];
+  specialDisks.map((formDisk) => {
+    const index = formik.values.devices.indexOf(formDisk);
+
+    rows.push(
+      getConfigurationRowBase({
+        className: "no-border-top custom-device-name",
+        configuration: (
+          <RenameDeviceInput
+            name={formDisk.name}
+            index={index}
+            setName={(name) => {
+              ensureEditMode(formik);
+              void formik.setFieldValue(`devices.${index}.name`, name);
+            }}
+          />
+        ),
+        inherited: "",
+        override: (
+          <DetachDiskDeviceBtn
+            onDetach={() => {
+              ensureEditMode(formik);
+              removeDevice(index, formik);
+            }}
+          />
+        ),
+      }),
+    );
+
+    rows.push(
+      getConfigurationRowBase({
+        className: "no-border-top inherited-with-form",
+        configuration: (
+          <Label forId={`devices.${index}.source`}>Source</Label>
+        ),
+        inherited: (
+          <div className="custom-disk-volume-source">
+            <Select
+              name={`devices.${index}.source`}
+              id={`devices.${index}.source`}
+              onBlur={formik.handleBlur}
+              onChange={(e) => {
+                ensureEditMode(formik);
+                void formik.setFieldValue(`devices.${index}.source`, e.target.value);
+              }}
+              value={formDisk.source}
+              options={getSourceOptions()}
+            />
+          </div>
+        ),
+        override: "",
+      }),
+    );
+  });
+
+  return (
+    <div className="custom-devices">
+      {specialDisks.length > 0 && (
+        <>
+          <h2 className="p-heading--4 custom-devices-heading">
+            Special disk devices
+          </h2>
+          <ConfigurationTable rows={rows} />
+        </>
+      )}
+      <Button
+        type="button"
+        hasIcon
+        onClick={() => {
+          ensureEditMode(formik);
+          addSpecialDisk();
+        }}
+      >
+        <Icon name="plus" />
+        <span>Attach special disk</span>
+      </Button>
+    </div>
+  );
+};
+
+export default DiskDeviceFormSpecial;

--- a/src/util/instanceValidation.tsx
+++ b/src/util/instanceValidation.tsx
@@ -81,3 +81,7 @@ export const isNicDeviceNameMissing = (
 
   return Boolean(hasTouched);
 };
+
+export const isSpecialDisk = (device: FormDevice): device is FormDiskDevice => {
+    return ["agent:config", "cloud-init:config"].includes(device.source);
+};


### PR DESCRIPTION
This PR introduces the ability to add special disk devices (`agent:config`, `cloud-init:config`) to instances (virtual machines).

## Screenshots
![Screenshot from 2024-12-19 11-51-21](https://github.com/user-attachments/assets/7f50e333-00b3-4408-8d2f-e5de9d95b05d)
