### PR TITLE
Support for network ACLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,10 @@ const CreateClusterGroup = lazy(
 );
 const CreateInstance = lazy(() => import("pages/instances/CreateInstance"));
 const CreateNetwork = lazy(() => import("pages/networks/CreateNetwork"));
+const CreateNetworkAcl = lazy(() => import("pages/networks/CreateNetworkAcl"));
+const CreateNetworkAclRule = lazy(
+  () => import("pages/networks/CreateNetworkAclRule"),
+);
 const CreateNetworkForward = lazy(
   () => import("pages/networks/CreateNetworkForward"),
 );
@@ -39,6 +43,8 @@ const Login = lazy(() => import("pages/login/Login"));
 const NetworkDetail = lazy(() => import("pages/networks/NetworkDetail"));
 const NetworkList = lazy(() => import("./pages/networks/NetworkList"));
 const NetworkMap = lazy(() => import("pages/networks/NetworkMap"));
+const NetworkAclDetail = lazy(() => import("pages/networks/NetworkAclDetail"));
+const NetworkAclList = lazy(() => import("./pages/networks/NetworkAclList"));
 const OperationList = lazy(() => import("pages/operations/OperationList"));
 const ProfileDetail = lazy(() => import("pages/profiles/ProfileDetail"));
 const ProfileList = lazy(() => import("pages/profiles/ProfileList"));
@@ -255,6 +261,54 @@ const App: FC = () => {
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<NetworkMap />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/network-acls"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<NetworkAclList />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/network-acls/create"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<CreateNetworkAcl />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/network-acls/:name"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<NetworkAclDetail />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/network-acls/:name/:activeTab"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<NetworkAclDetail />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/network-acls/:name/:activeTab/:section"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<NetworkAclDetail />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/network-acls/:acl/rules/create/:type"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<CreateNetworkAclRule />} />}
             />
           }
         />

--- a/src/api/networks.tsx
+++ b/src/api/networks.tsx
@@ -1,5 +1,9 @@
 import { handleEtagResponse, handleResponse } from "util/helpers";
-import { LxdNetwork, LxdNetworkState } from "types/network";
+import {
+  LxdNetwork,
+  LxdNetworkAcl,
+  LxdNetworkState
+} from "types/network";
 import { LxdApiResponse } from "types/apiResponse";
 import { LxdClusterMember } from "types/cluster";
 import { areNetworksEqual } from "util/networks";
@@ -186,5 +190,88 @@ export const deleteNetwork = (name: string, project: string): Promise<void> => {
         }
         reject(e);
       });
+  });
+};
+
+export const fetchNetworkAcls = (project: string): Promise<LxdNetworkAcl[]> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/network-acls?project=${project}&recursion=1`)
+      .then(handleResponse)
+      .then((data: LxdApiResponse<LxdNetworkAcl[]>) => resolve(data.metadata))
+      .catch(reject);
+  });
+};
+
+export const fetchNetworkAcl = (
+  name: string,
+  project: string,
+): Promise<LxdNetworkAcl> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/network-acls/${name}?project=${project}`)
+      .then(handleEtagResponse)
+      .then((data) => resolve(data as LxdNetworkAcl))
+      .catch(reject);
+  });
+};
+
+export const createNetworkAcl = (
+  acl: Partial<LxdNetworkAcl>,
+  project: string,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/network-acls?project=${project}`, {
+      method: "POST",
+      body: JSON.stringify(acl),
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const updateNetworkAcl = (
+  acl: Partial<LxdNetworkAcl> & Required<Pick<LxdNetworkAcl, "config">>,
+  project: string,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/network-acls/${acl.name ?? ""}?project=${project}`, {
+      method: "PUT",
+      body: JSON.stringify(acl),
+      headers: {
+        "If-Match": acl.etag ?? "invalid-etag",
+      },
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const renameNetworkAcl = (
+  oldName: string,
+  newName: string,
+  project: string,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/network-acls/${oldName}?project=${project}`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: newName,
+      }),
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const deleteNetworkAcl = (name: string, project: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/network-acls/${name}?project=${project}`, {
+      method: "DELETE",
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
   });
 };

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -219,17 +219,42 @@ const Navigation: FC = () => {
                       </SideNavigationItem>
 
                       <SideNavigationItem>
-                        <NavLink
-                          to={`/ui/project/${projectName}/networks`}
-                          title={`Networks (${projectName})`}
-                          onClick={softToggleMenu}
+                        <NavAccordion
+                          baseUrl={`/ui/project/${projectName}/networks`}
+                          title={`Networking (${projectName})`}
+                          iconName="exposed"
+                          label="Networking"
+                          onOpen={() => toggleAccordionNav("networks")}
+                          open={openNavMenus.includes("networks")}
                         >
-                          <Icon
-                            className="is-light p-side-navigation__icon"
-                            name="exposed"
-                          />{" "}
-                          Networks
-                        </NavLink>
+                          {[
+                            <SideNavigationItem
+                              key={`/ui/project/${projectName}/networks`}
+                            >
+                              <NavLink
+                                to={`/ui/project/${projectName}/networks`}
+                                title={`Networks (${projectName})`}
+                                onClick={softToggleMenu}
+                                className="accordion-nav-secondary"
+                                ignoreUrlMatches={["network-acls"]}
+                              >
+                                Networks
+                              </NavLink>
+                            </SideNavigationItem>,
+                            <SideNavigationItem
+                              key={`/ui/project/${projectName}/network-acls`}
+                            >
+                              <NavLink
+                                to={`/ui/project/${projectName}/network-acls`}
+                                title={`ACL (${projectName})`}
+                                onClick={softToggleMenu}
+                                className="accordion-nav-secondary"
+                              >
+                                ACLs
+                              </NavLink>
+                            </SideNavigationItem>,
+                          ]}
+                        </NavAccordion>
                       </SideNavigationItem>
                       <SideNavigationItem>
                         <NavAccordion

--- a/src/pages/networks/CreateNetworkAcl.tsx
+++ b/src/pages/networks/CreateNetworkAcl.tsx
@@ -1,0 +1,137 @@
+import { FC, useState } from "react";
+import { ActionButton, Button, useNotify } from "@canonical/react-components";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { useNavigate, useParams } from "react-router-dom";
+import { checkDuplicateName } from "util/helpers";
+import { createNetworkAcl } from "api/networks";
+import NetworkAclForm, {
+  NetworkAclFormValues,
+  toNetworkAcl,
+} from "pages/networks/forms/NetworkAclForm";
+import NotificationRow from "components/NotificationRow";
+import { yamlToObject } from "util/yaml";
+import { dump as dumpYaml } from "js-yaml";
+import BaseLayout from "components/BaseLayout";
+import { MAIN_CONFIGURATION } from "pages/networks/forms/NetworkAclFormMenu";
+import { slugify } from "util/slugify";
+import FormFooterLayout from "components/forms/FormFooterLayout";
+import { useToastNotification } from "context/toastNotificationProvider";
+import YamlSwitch from "components/forms/YamlSwitch";
+import ResourceLink from "components/ResourceLink";
+
+const CreateNetworkAcl: FC = () => {
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const queryClient = useQueryClient();
+  const { project } = useParams<{ project: string }>();
+  const [section, setSection] = useState(slugify(MAIN_CONFIGURATION));
+  const controllerState = useState<AbortController | null>(null);
+
+  if (!project) {
+    return <>Missing project</>;
+  }
+
+  const NetworkAclSchema = Yup.object().shape({
+    name: Yup.string()
+      .test("deduplicate", "A network ACL with this name already exists", (value) =>
+        checkDuplicateName(value, project, controllerState, "network-acls"),
+      )
+      .required("Network ACL name is required"),
+  });
+
+  const formik = useFormik<NetworkAclFormValues>({
+    initialValues: {
+      readOnly: false,
+      isCreating: true,
+      name: "",
+      entityType: "networkAcl",
+    },
+    validationSchema: NetworkAclSchema,
+    onSubmit: (values) => {
+      const acl = values.yaml
+        ? yamlToObject(values.yaml)
+        : toNetworkAcl(values);
+
+      createNetworkAcl(acl, project)
+        .then(() => {
+          void queryClient.invalidateQueries({
+            queryKey: [queryKeys.projects, project, queryKeys.networkAcls],
+          });
+          navigate(`/ui/project/${project}/network-acls`);
+          toastNotify.success(
+            <>
+              Network ACL{" "}
+              <ResourceLink
+                type="network-acl"
+                value={values.name}
+                to={`/ui/project/${project}/network-acls/${values.name}`}
+              />{" "}
+              created.
+            </>,
+          );
+        })
+        .catch((e) => {
+          formik.setSubmitting(false);
+          notify.failure("Network ACL creation failed", e);
+        });
+    },
+  });
+
+  const getYaml = () => {
+    const payload = toNetworkAcl(formik.values);
+    return dumpYaml(payload);
+  };
+
+  const updateSection = (newSection: string) => {
+    setSection(slugify(newSection));
+  };
+
+  return (
+    <BaseLayout title="Create a network ACL" contentClassName="create-network">
+      <NotificationRow />
+      <NetworkAclForm
+        formik={formik}
+        getYaml={getYaml}
+        project={project}
+        section={section}
+        setSection={updateSection}
+      />
+      <FormFooterLayout>
+        <div className="yaml-switch">
+          <YamlSwitch
+            formik={formik}
+            section={section}
+            setSection={updateSection}
+            disableReason={
+              formik.values.name
+                ? undefined
+                : "Please enter a network ACL name to enable this section"
+            }
+          />
+        </div>
+        <Button
+          appearance="base"
+          onClick={() => navigate(`/ui/project/${project}/network-acls`)}
+        >
+          Cancel
+        </Button>
+        <ActionButton
+          appearance="positive"
+          loading={formik.isSubmitting}
+          disabled={
+            !formik.isValid || !formik.values.name
+          }
+          onClick={() => void formik.submitForm()}
+        >
+          Create
+        </ActionButton>
+      </FormFooterLayout>
+    </BaseLayout>
+  );
+};
+
+export default CreateNetworkAcl;

--- a/src/pages/networks/CreateNetworkAclRule.tsx
+++ b/src/pages/networks/CreateNetworkAclRule.tsx
@@ -1,0 +1,111 @@
+import { FC, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { ActionButton, useNotify } from "@canonical/react-components";
+import { useFormik } from "formik";
+import NetworkAclRuleForm, {
+  NetworkAclRuleFormValues,
+  NetworkAclRuleSchema,
+  toNetworkAclRule,
+} from "pages/networks/forms/NetworkAclRuleForm";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import BaseLayout from "components/BaseLayout";
+import { useDocs } from "context/useDocs";
+import HelpLink from "components/HelpLink";
+import FormFooterLayout from "components/forms/FormFooterLayout";
+import { useToastNotification } from "context/toastNotificationProvider";
+import { updateNetworkAcl } from "api/networks";
+import { toNetworkAclFormValues } from "util/networkForm";
+
+const CreateNetworkAclRule: FC = () => {
+  const docBaseLink = useDocs();
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const queryClient = useQueryClient();
+  const [showNotify, setShowNotify] = useState(false);
+  const { acl: aclName, project, type } = useParams<{
+    acl: string;
+    project: string;
+    type: string;
+  }>();
+
+  const { data: acl } = useQuery({
+    queryKey: [queryKeys.projects, project, queryKeys.networkAcls, aclName],
+    queryFn: () => fetchNetworkAcl(aclName, project),
+  });
+
+  const formik = useFormik<NetworkAclRuleFormValues>({
+    initialValues: {
+      readOnly: false,
+      isCreating: true,
+      action: "allow",
+      state: "enabled",
+    },
+    validationSchema: NetworkAclRuleSchema,
+    onSubmit: (values) => {
+      const rule = toNetworkAclRule(values);
+      const tmpAcl = {...acl, ingress:[...acl.ingress], egress:[...acl.egress]}
+      tmpAcl[type].push(rule);
+      updateNetworkAcl({ ...tmpAcl, etag: tmpAcl.etag }, project)
+        .then(() => {
+          formik.resetForm({
+            values: toNetworkAclFormValues(tmpAcl),
+          });
+
+          void queryClient.invalidateQueries({
+            queryKey: [
+              queryKeys.projects,
+              project,
+              queryKeys.networkAcls,
+              acl.name,
+            ],
+          });
+          navigate(`/ui/project/${project}/network-acls/${aclName}/${type}`);
+          toastNotify.success(
+            <>
+              Network ACL rule added.
+            </>,
+          );
+        })
+        .catch((e) => {
+          notify.failure("Network ACL rule update failed", e);
+          setShowNotify(!showNotify);
+        })
+        .finally(() => formik.setSubmitting(false));
+    },
+  });
+
+  return (
+    <BaseLayout
+      title={
+        <HelpLink
+          href={`${docBaseLink}/howto/network_acls/`}
+          title="Learn more about network ACLs"
+        >
+          Create a network ACL rule
+        </HelpLink>
+      }
+      contentClassName="create-network"
+    >
+      <NetworkAclRuleForm formik={formik} acl={acl} showNotify={showNotify}/>
+      <FormFooterLayout>
+        <Link
+          className="p-button--base"
+          to={`/ui/project/${project}/network-acls/${aclName}/${type}`}
+        >
+          Cancel
+        </Link>
+        <ActionButton
+          loading={formik.isSubmitting}
+          disabled={!formik.isValid}
+          onClick={() => void formik.submitForm()}
+        >
+          Create
+        </ActionButton>
+      </FormFooterLayout>
+    </BaseLayout>
+  );
+};
+
+export default CreateNetworkAclRule;

--- a/src/pages/networks/EditNetworkAcl.tsx
+++ b/src/pages/networks/EditNetworkAcl.tsx
@@ -1,0 +1,153 @@
+import { FC, useState } from "react";
+import { Button, useNotify } from "@canonical/react-components";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { checkDuplicateName } from "util/helpers";
+import { updateNetworkAcl } from "api/networks";
+import NetworkAclForm, {
+  NetworkAclFormValues,
+  toNetworkAcl,
+} from "pages/networks/forms/NetworkAclForm";
+import { LxdNetworkAcl } from "types/network";
+import { yamlToObject } from "util/yaml";
+import { dump as dumpYaml } from "js-yaml";
+import { toNetworkAclFormValues } from "util/networkForm";
+import { slugify } from "util/slugify";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  MAIN_CONFIGURATION,
+  YAML_CONFIGURATION,
+} from "pages/networks/forms/NetworkAclFormMenu";
+import FormFooterLayout from "components/forms/FormFooterLayout";
+import { useToastNotification } from "context/toastNotificationProvider";
+import YamlSwitch from "components/forms/YamlSwitch";
+import FormSubmitBtn from "components/forms/FormSubmitBtn";
+import ResourceLink from "components/ResourceLink";
+
+interface Props {
+  network: LxdNetworkAcl;
+  project: string;
+}
+
+const EditNetworkAcl: FC<Props> = ({ acl, project }) => {
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+
+  const { section } = useParams<{ section?: string }>();
+  const queryClient = useQueryClient();
+  const controllerState = useState<AbortController | null>(null);
+  const [version, setVersion] = useState(0);
+
+  const NetworkAclSchema = Yup.object().shape({
+    name: Yup.string()
+      .test(
+        "deduplicate",
+        "A network ACL with this name already exists",
+        (value) =>
+          value === acl.name ||
+          checkDuplicateName(value, project, controllerState, "network-acls"),
+      )
+      .required("Network ACL name is required"),
+  });
+
+  const formik = useFormik<NetworkFormValues>({
+    initialValues: toNetworkAclFormValues(acl),
+    validationSchema: NetworkAclSchema,
+    enableReinitialize: true,
+    onSubmit: (values) => {
+      const yaml = values.yaml ? values.yaml : getYaml();
+      const saveAcl = yamlToObject(yaml) as LxdNetworkAcl;
+      updateNetworkAcl({ ...saveAcl, etag: acl.etag }, project)
+        .then(() => {
+          formik.resetForm({
+            values: toNetworkAclFormValues(saveAcl),
+          });
+
+          void queryClient.invalidateQueries({
+            queryKey: [
+              queryKeys.projects,
+              project,
+              queryKeys.networkAcls,
+              acl.name,
+            ],
+          });
+          toastNotify.success(
+            <>
+              Network ACL{""}
+              <ResourceLink
+                type="network-acl"
+                value={acl.name}
+                to={`/ui/project/${project}/network-acls/${acl.name}`}
+              />{" "}
+              updated.
+            </>,
+          );
+        })
+        .catch((e) => {
+          notify.failure("Network ACL update failed", e);
+        })
+        .finally(() => formik.setSubmitting(false));
+    },
+  });
+
+  const getYaml = () => {
+    return dumpYaml(toNetworkAcl(formik.values));
+  };
+
+  const setSection = (newSection: string) => {
+    const baseUrl = `/ui/project/${project}/network-acls/${acl.name}/configuration`;
+    newSection === MAIN_CONFIGURATION
+      ? navigate(baseUrl)
+      : navigate(`${baseUrl}/${slugify(newSection)}`);
+  };
+
+  const readOnly = formik.values.readOnly;
+
+  return (
+    <>
+      <NetworkAclForm
+        formik={formik}
+        getYaml={getYaml}
+        project={project}
+        section={section ?? slugify(MAIN_CONFIGURATION)}
+        setSection={setSection}
+        version={version}
+      />
+      <FormFooterLayout>
+        <YamlSwitch
+          formik={formik}
+          section={section}
+          setSection={setSection}
+          disableReason={
+            formik.values.name
+              ? undefined
+              : "Please enter a network ACL name to enable this section"
+          }
+        />
+        {readOnly ? null : (
+          <>
+            <Button
+              appearance="base"
+              onClick={() => {
+                setVersion((old) => old + 1);
+                void formik.setValues(toNetworkAclFormValues(acl));
+              }}
+            >
+              Cancel
+            </Button>
+            <FormSubmitBtn
+              formik={formik}
+              isYaml={section === slugify(YAML_CONFIGURATION)}
+              disabled={!formik.values.name}
+            />
+          </>
+        )}
+      </FormFooterLayout>
+    </>
+  );
+};
+
+export default EditNetworkAcl;

--- a/src/pages/networks/NetworkAclDetail.tsx
+++ b/src/pages/networks/NetworkAclDetail.tsx
@@ -1,0 +1,83 @@
+import { FC } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { useParams } from "react-router-dom";
+import { fetchNetworkAcl } from "api/networks";
+import NotificationRow from "components/NotificationRow";
+import EditNetworkAcl from "pages/networks/EditNetworkAcl";
+import NetworkAclDetailHeader from "pages/networks/NetworkAclDetailHeader";
+import Loader from "components/Loader";
+import { Row } from "@canonical/react-components";
+import NetworkAclDetailOverview from "pages/networks/NetworkAclDetailOverview";
+import NetworkAclRules from "pages/networks/NetworkAclRules";
+import CustomLayout from "components/CustomLayout";
+import TabLinks from "components/TabLinks";
+
+const NetworkAclDetail: FC = () => {
+  const { name, project, activeTab } = useParams<{
+    name: string;
+    project: string;
+    activeTab?: string;
+  }>();
+
+  if (!name) {
+    return <>Missing name</>;
+  }
+
+  if (!project) {
+    return <>Missing project</>;
+  }
+
+  const { data: acl, isLoading } = useQuery({
+    queryKey: [queryKeys.projects, project, queryKeys.networkAcls, name],
+    queryFn: () => fetchNetworkAcl(name, project),
+  });
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  const getTabs = () => {
+    return ["Overview", "Configuration", "Ingress", "Egress"];
+  };
+
+  return (
+    <CustomLayout
+      header={
+        <NetworkAclDetailHeader acl={acl} project={project} name={name} />
+      }
+      contentClassName="edit-network"
+    >
+      <Row>
+        <TabLinks
+          tabs={getTabs()}
+          activeTab={activeTab}
+          tabUrl={`/ui/project/${project}/network-acls/${name}`}
+        />
+        <NotificationRow />
+        {!activeTab && (
+          <div role="tabpanel" aria-labelledby="overview">
+            {acl && <NetworkAclDetailOverview acl={acl} />}
+          </div>
+        )}
+        {activeTab === "configuration" && (
+          <div role="tabpanel" aria-labelledby="configuration">
+            {acl && <EditNetworkAcl acl={acl} project={project} />}
+          </div>
+        )}
+        {activeTab === "ingress" && (
+          <div role="tabpanel" aria-labelledby="ingress">
+            {acl && <NetworkAclRules acl={acl} type="ingress" project={project} />}
+          </div>
+        )}
+        {activeTab === "egress" && (
+          <div role="tabpanel" aria-labelledby="egress">
+            {acl && <NetworkAclRules acl={acl} type="egress" project={project} />}
+          </div>
+        )}
+      </Row>
+    </CustomLayout>
+  );
+};
+
+export default NetworkAclDetail;

--- a/src/pages/networks/NetworkAclDetailHeader.tsx
+++ b/src/pages/networks/NetworkAclDetailHeader.tsx
@@ -1,0 +1,91 @@
+import { FC, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import RenameHeader, { RenameHeaderValues } from "components/RenameHeader";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { checkDuplicateName } from "util/helpers";
+import { LxdNetworkAcl } from "types/network";
+import { renameNetworkAcl } from "api/networks";
+import DeleteNetworkAclBtn from "pages/networks/actions/DeleteNetworkAclBtn";
+import { useNotify } from "@canonical/react-components";
+import { useToastNotification } from "context/toastNotificationProvider";
+import ResourceLink from "components/ResourceLink";
+
+interface Props {
+  name: string;
+  acl?: LxdNetworkAcl;
+  project: string;
+}
+
+const NetworkAclDetailHeader: FC<Props> = ({ name, acl, project }) => {
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const controllerState = useState<AbortController | null>(null);
+
+  const RenameSchema = Yup.object().shape({
+    name: Yup.string()
+      .test(
+        "deduplicate",
+        "A network ACL with this name already exists",
+        (value) =>
+          acl?.name === value ||
+          checkDuplicateName(value, project, controllerState, "network-acls"),
+      )
+      .required("Network ACL name is required"),
+  });
+
+  const formik = useFormik<RenameHeaderValues>({
+    initialValues: {
+      name,
+      isRenaming: false,
+    },
+    validationSchema: RenameSchema,
+    onSubmit: (values) => {
+      if (name === values.name) {
+        void formik.setFieldValue("isRenaming", false);
+        formik.setSubmitting(false);
+        return;
+      }
+      renameNetworkAcl(name, values.name, project)
+        .then(() => {
+          const url = `/ui/project/${project}/network-acls/${values.name}`;
+          navigate(url);
+          toastNotify.success(
+            <>
+              Network ACL<strong>{name}</strong> renamed to{" "}
+              <ResourceLink type="network-acl" value={values.name} to={url} />.
+            </>,
+          );
+          void formik.setFieldValue("isRenaming", false);
+        })
+        .catch((e) => {
+          notify.failure("Renaming failed", e);
+        })
+        .finally(() => formik.setSubmitting(false));
+    },
+  });
+
+  const isUsed = (acl?.used_by?.length ?? 0) > 0;
+
+  return (
+    <RenameHeader
+      name={name}
+      parentItems={[
+        <Link to={`/ui/project/${project}/network-acls`} key={1}>
+          Network ACLs
+        </Link>,
+      ]}
+      renameDisabledReason={
+        isUsed ? "Can not rename, network ACL is currently in use." : undefined
+      }
+      controls={
+        acl && <DeleteNetworkAclBtn acl={acl} project={project} />
+      }
+      isLoaded={Boolean(acl)}
+      formik={formik}
+    />
+  );
+};
+
+export default NetworkAclDetailHeader;

--- a/src/pages/networks/NetworkAclDetailOverview.tsx
+++ b/src/pages/networks/NetworkAclDetailOverview.tsx
@@ -1,0 +1,140 @@
+import { FC } from "react";
+import { useParams } from "react-router-dom";
+import { Col, Row } from "@canonical/react-components";
+import useEventListener from "@use-it/event-listener";
+import { updateMaxHeight } from "util/updateMaxHeight";
+import ItemName from "components/ItemName";
+import { LxdNetworkAcl } from "types/network";
+import { filterUsedByType, LxdUsedBy } from "util/usedBy";
+import ExpandableList from "components/ExpandableList";
+import UsedByItem from "components/UsedByItem";
+
+interface Props {
+  acl: LxdNetworkAcl;
+}
+
+const NetworkAclDetailOverview: FC<Props> = ({ acl }) => {
+  const { project } = useParams<{ project: string }>();
+
+  if (!project) {
+    return <>Missing project</>;
+  }
+
+  const updateContentHeight = () => {
+    updateMaxHeight("network-overview-tab");
+  };
+  useEventListener("resize", updateContentHeight);
+
+  const usageCount = acl.used_by?.length ?? 0;
+
+  const data: Record<string, LxdUsedBy[]> = {
+    instances: filterUsedByType("instance", acl.used_by),
+    profiles: filterUsedByType("profile", acl.used_by),
+    networks: filterUsedByType("network", acl.used_by),
+  };
+
+  return (
+    <div className="network-overview-tab">
+      <Row className="section">
+        <Col size={3}>
+          <h2 className="p-heading--5">General</h2>
+        </Col>
+        <Col size={7}>
+          <table>
+            <tbody>
+              <tr>
+                <th className="u-text--muted">Name</th>
+                <td>
+                  <ItemName item={acl} />
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">Description</th>
+                <td>{acl.description ? acl.description : "-"}</td>
+              </tr>
+            </tbody>
+          </table>
+        </Col>
+      </Row>
+      <Row className="usage list-wrapper">
+        <Col size={3}>
+          <h2 className="p-heading--5">Usage ({usageCount})</h2>
+        </Col>
+        <Col size={7}>
+          <table>
+            <tbody>
+              <tr className="list-wrapper">
+                <th className="u-text--muted">
+                  Networks ({data.networks.length})
+                </th>
+                <td>
+                  {data.networks.length > 0 ? (
+                    <ExpandableList
+                      items={data.networks.map((item) => (
+                        <UsedByItem
+                          key={item.name}
+                          item={item}
+                          activeProject={project}
+                          type="network"
+                          to={`/ui/project/${item.project}/network/${item.name}`}
+                        />
+                      ))}
+                    />
+                  ) : (
+                    "-"
+                  )}
+                </td>
+              </tr>
+              <tr className="list-wrapper">
+                <th className="u-text--muted">
+                  Instances ({data.instances.length})
+                </th>
+                <td>
+                  {data.instances.length > 0 ? (
+                    <ExpandableList
+                      items={data.instances.map((item) => (
+                        <UsedByItem
+                          key={item.name}
+                          item={item}
+                          activeProject={project}
+                          type="instance"
+                          to={`/ui/project/${item.project}/instance/${item.name}`}
+                        />
+                      ))}
+                    />
+                  ) : (
+                    "-"
+                  )}
+                </td>
+              </tr>
+              <tr className="list-wrapper">
+                <th className="u-text--muted">
+                  Profiles ({data.profiles.length})
+                </th>
+                <td>
+                  {data.profiles.length > 0 ? (
+                    <ExpandableList
+                      items={data.profiles.map((item) => (
+                        <UsedByItem
+                          key={item.name}
+                          item={item}
+                          activeProject={project}
+                          type="profile"
+                          to={`/ui/project/${item.project}/profile/${item.name}`}
+                        />
+                      ))}
+                    />
+                  ) : (
+                    "-"
+                  )}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+export default NetworkAclDetailOverview;

--- a/src/pages/networks/NetworkAclList.tsx
+++ b/src/pages/networks/NetworkAclList.tsx
@@ -1,0 +1,152 @@
+import { FC } from "react";
+import {
+  Button,
+  EmptyState,
+  Icon,
+  MainTable,
+  Row,
+  useNotify,
+} from "@canonical/react-components";
+import { fetchNetworkAcls } from "api/networks";
+import BaseLayout from "components/BaseLayout";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import Loader from "components/Loader";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import NotificationRow from "components/NotificationRow";
+import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
+import { useSmallScreen } from "context/useSmallScreen";
+
+const NetworkAclList: FC = () => {
+  const docBaseLink = useDocs();
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const { project } = useParams<{ project: string }>();
+  const isSmallScreen = useSmallScreen();
+
+  if (!project) {
+    return <>Missing project</>;
+  }
+
+  const {
+    data: acls = [],
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: [queryKeys.projects, project, queryKeys.networkAcls],
+    queryFn: () => fetchNetworkAcls(project),
+  });
+
+  if (error) {
+    notify.failure("Loading network ACLs failed", error);
+  }
+
+  const hasAcls = acls.length > 0;
+
+  const headers = [
+    { content: "Name", sortKey: "name" },
+    { content: "Description", sortKey: "description" },
+    { content: "Used by", sortKey: "usedBy", className: "u-align--right" },
+  ];
+
+  const rows = acls.map((acl) => {
+    return {
+      columns: [
+        {
+          content: (
+            <Link to={`/ui/project/${project}/network-acls/${acl.name}`}>
+              {acl.name}
+            </Link>
+          ),
+          role: "rowheader",
+          "aria-label": "Name",
+        },
+        {
+          content: acl.description,
+          role: "rowheader",
+          "aria-label": "Description",
+        },
+        {
+          content: acl.used_by?.length ?? "0",
+          role: "rowheader",
+          className: "u-align--right",
+          "aria-label": "Used by",
+        },
+      ],
+      sortData: {
+        name: acl.name.toLowerCase(),
+        description: acl.description?.toLowerCase(),
+        usedBy: acl.used_by?.length ?? 0,
+      },
+    };
+  });
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  return (
+    <>
+      <BaseLayout
+        title={
+          <HelpLink
+            href={`${docBaseLink}/explanation/networks/`}
+            title="Learn more about networking"
+          >
+            ACLs
+          </HelpLink>
+        }
+        controls={
+          <>
+            <Button
+              appearance="positive"
+              className="u-no-margin--bottom"
+              onClick={() => navigate(`/ui/project/${project}/network-acls/create`)}
+              hasIcon={!isSmallScreen}
+            >
+              {!isSmallScreen && <Icon name="plus" light />}
+              <span>Create ACL</span>
+            </Button>
+          </>
+        }
+      >
+        <NotificationRow />
+        <Row>
+          {hasAcls && (
+            <MainTable
+              headers={headers}
+              rows={rows}
+              paginate={30}
+              responsive
+              sortable
+              className="u-table-layout--auto"
+              emptyStateMsg="No data to display"
+            />
+          )}
+          {!isLoading && !hasAcls && (
+            <EmptyState
+              className="empty-state"
+              image={<Icon className="empty-state-icon" name="exposed" />}
+              title="No network ACLs found"
+            >
+              <p>There are no network ACLs in this project.</p>
+              <p>
+                <a
+                  href={`${docBaseLink}/explanation/network-acls/`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn more about network ACLs
+                  <Icon className="external-link-icon" name="external-link" />
+                </a>
+              </p>
+            </EmptyState>
+          )}
+        </Row>
+      </BaseLayout>
+    </>
+  );
+};
+
+export default NetworkAclList;

--- a/src/pages/networks/NetworkAclRuleDetailPanel.tsx
+++ b/src/pages/networks/NetworkAclRuleDetailPanel.tsx
@@ -1,0 +1,105 @@
+import { FC } from "react";
+import { Button, Icon, useNotify } from "@canonical/react-components";
+import SidePanel from "components/SidePanel";
+
+interface Props {
+  rule: Object;
+  onClosePanel: () => void;
+}
+
+const NetworkAclRuleDetailPanel: FC<Props> = ({ rule, onClosePanel }) => {
+  return (
+    <SidePanel
+      className="u-hide--medium u-hide--small"
+      width="narrow"
+      pinned
+    >
+      <SidePanel.Container className="detail-panel profile-detail-panel">
+        <SidePanel.Sticky>
+          <SidePanel.Header>
+            <SidePanel.HeaderTitle>ACL rule summary</SidePanel.HeaderTitle>
+            <SidePanel.HeaderControls>
+              <Button
+                appearance="base"
+                className="u-no-margin--bottom"
+                hasIcon
+                onClick={onClosePanel}
+                aria-label="Close"
+              >
+                <Icon name="close" />
+              </Button>
+            </SidePanel.HeaderControls>
+          </SidePanel.Header>
+        </SidePanel.Sticky>
+        <SidePanel.Content>
+          <table className="u-table-layout--auto u-no-margin--bottom">
+            <tbody>
+              <tr>
+                <th className="u-text--muted">Action</th>
+                <td>
+                  { rule.action }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">State</th>
+                <td>
+                  { rule.state }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">Description</th>
+                <td>
+                  { rule.description }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">Source</th>
+                <td>
+                  { rule.source }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">Destination</th>
+                <td>
+                  { rule.destination }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">Protocol</th>
+                <td>
+                  { rule.protocol }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">Source port</th>
+                <td>
+                  { rule.source_port }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">Destination port</th>
+                <td>
+                  { rule.destination_port }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">ICMP type</th>
+                <td>
+                  { rule.icmp_type }
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">ICMP code</th>
+                <td>
+                  { rule.icmp_code }
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </SidePanel.Content>
+      </SidePanel.Container>
+    </SidePanel>
+  );
+};
+
+export default NetworkAclRuleDetailPanel;

--- a/src/pages/networks/NetworkAclRules.tsx
+++ b/src/pages/networks/NetworkAclRules.tsx
@@ -1,0 +1,149 @@
+import { FC, useState } from "react";
+import {
+  EmptyState,
+  Icon,
+  MainTable,
+  Row,
+} from "@canonical/react-components";
+import { LxdNetworkAcl } from "types/network";
+import { useDocs } from "context/useDocs";
+import { Link } from "react-router-dom";
+import ScrollableTable from "components/ScrollableTable";
+import DeleteNetworkAclRuleBtn from "pages/networks/actions/DeleteNetworkAclRuleBtn";
+import NetworkAclRuleDetailPanel from "./NetworkAclRuleDetailPanel.tsx"
+
+interface Props {
+  acl: LxdNetworkAcl;
+  type: string;
+  project: string;
+}
+
+const NetworkAclRules: FC<Props> = ({ acl, type, project }) => {
+  const docBaseLink = useDocs();
+  const [selectedRule, setSelectedRule] = useState(-1);
+
+  const hasRules = acl[type].length > 0;
+  const rules = acl[type];
+
+  const closeDetailPanel = () => setSelectedRule(-1);
+
+  const headers = [
+    { content: "Action", sortKey: "action" },
+    { content: "State", sortKey: "state" },
+    { content: "Description", sortKey: "description" },
+    { content: "Source", sortKey: "source" },
+    { content: "Destination", sortKey: "destination" },
+    { "aria-label": "Actions", className: "u-align--right actions" },
+  ];
+
+  const rows = rules.map((rule, index) => {
+    const openDetailPanel = () => setSelectedRule(index);
+
+    return {
+      className:
+        selectedRule === index ? "u-row-selected" : "u-row",
+      columns: [
+        {
+          content: rule.action,
+          "aria-label": "Action",
+          onClick: openDetailPanel,
+        },
+        {
+          content: rule.state,
+          "aria-label": "State",
+          onClick: openDetailPanel,
+        },
+        {
+          content: rule.description,
+          "aria-label": "Description",
+          onClick: openDetailPanel,
+        },
+        {
+          content: rule.source,
+          "aria-label": "Source",
+          onClick: openDetailPanel,
+        },
+        {
+          content: rule.destination,
+          "aria-label": "Destination",
+          onClick: openDetailPanel,
+        },
+        {
+          content: (
+            <>
+              <DeleteNetworkAclRuleBtn
+                acl={acl}
+                project={project}
+                index={index}
+                type={type}
+                onDelete={closeDetailPanel}
+              />
+            </>
+          ),
+          className: "u-align--right actions",
+          "aria-label": "Actions",
+        },
+      ],
+      sortData: {
+        action: rule.action,
+        state: rule.state,
+        description: rule.description,
+      },
+    };
+  });
+
+  return (
+    <>
+      <Link
+        className="p-button--positive u-no-margin--bottom u-float-right"
+        to={`/ui/project/${project}/network-acls/${acl.name}/rules/create/${type}`}
+      >
+        Create rule
+      </Link>
+      <Row>
+        {hasRules && (
+          <ScrollableTable
+            dependencies={rules}
+            tableId="network-acl-rules-table"
+            belowIds={["status-bar"]}
+          >
+            <MainTable
+              id="network-acl-rules-table"
+              headers={headers}
+              expanding
+              rows={rows}
+              paginate={30}
+              sortable
+              defaultSort="action"
+              defaultSortDirection="ascending"
+              className="network-acl-rule-list u-table-layout--auto network-acl-rules-table u-selectable-table-rows"
+              emptyStateMsg="No data to display"
+            />
+          </ScrollableTable>
+        )}
+        {!hasRules && (
+          <EmptyState
+            className="empty-state"
+            image={<Icon className="empty-state-icon" name="exposed" />}
+            title="No network ACL rules found"
+          >
+            <p>There are no network ACL rules in this project.</p>
+            <p>
+              <a
+                href={`${docBaseLink}/howto/network_acls/`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn more about network ACLs.
+                <Icon className="external-link-icon" name="external-link" />
+              </a>
+            </p>
+          </EmptyState>
+        )}
+      </Row>
+      { selectedRule != -1 && <NetworkAclRuleDetailPanel rule={rules[selectedRule]} onClosePanel={closeDetailPanel}/> }
+    </>
+  );
+};
+
+export default NetworkAclRules;

--- a/src/pages/networks/actions/DeleteNetworkAclBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkAclBtn.tsx
@@ -1,0 +1,89 @@
+import { FC, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import ItemName from "components/ItemName";
+import { LxdNetworkAcl } from "types/network";
+import { deleteNetworkAcl } from "api/networks";
+import { queryKeys } from "util/queryKeys";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  ConfirmationButton,
+  Icon,
+  useNotify,
+} from "@canonical/react-components";
+import { useToastNotification } from "context/toastNotificationProvider";
+import ResourceLabel from "components/ResourceLabel";
+import { useSmallScreen } from "context/useSmallScreen";
+import classnames from "classnames";
+
+interface Props {
+  acl: LxdNetworkAcl;
+  project: string;
+}
+
+const DeleteNetworkAclBtn: FC<Props> = ({ acl, project }) => {
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const queryClient = useQueryClient();
+  const [isLoading, setLoading] = useState(false);
+  const navigate = useNavigate();
+  const isSmallScreen = useSmallScreen();
+
+  const handleDelete = () => {
+    setLoading(true);
+    deleteNetworkAcl(acl.name, project)
+      .then(() => {
+        void queryClient.invalidateQueries({
+          predicate: (query) =>
+            query.queryKey[0] === queryKeys.projects &&
+            query.queryKey[1] === project &&
+            query.queryKey[2] === queryKeys.networkAcls,
+        });
+        navigate(`/ui/project/${project}/network-acls`);
+        toastNotify.success(
+          <>
+            Network ACL <ResourceLabel bold type="network-acls" value={acl.name} />{" "}
+            deleted.
+          </>,
+        );
+      })
+      .catch((e) => {
+        setLoading(false);
+        notify.failure("Network ACL deletion failed", e);
+      });
+  };
+
+  const isUsed = (acl.used_by?.length ?? 0) > 0;
+
+  return (
+    <ConfirmationButton
+      onHoverText={
+        isUsed ? "Can not delete, network ACL is currently in use" : ""
+      }
+      confirmationModalProps={{
+        title: "Confirm delete",
+        confirmButtonAppearance: "negative",
+        confirmButtonLabel: "Delete",
+        children: (
+          <p>
+            Are you sure you want to delete the network ACL{" "}
+            <ItemName item={acl} bold />?<br />
+            This action cannot be undone, and can result in data loss.
+          </p>
+        ),
+        onConfirm: handleDelete,
+      }}
+      className={classnames("u-no-margin--bottom", {
+        "has-icon": !isSmallScreen,
+      })}
+      loading={isLoading}
+      disabled={isUsed}
+      shiftClickEnabled
+      showShiftClickHint
+    >
+      {!isSmallScreen && <Icon name="delete" />}
+      <span>Delete ACL</span>
+    </ConfirmationButton>
+  );
+};
+
+export default DeleteNetworkAclBtn;

--- a/src/pages/networks/actions/DeleteNetworkAclRuleBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkAclRuleBtn.tsx
@@ -1,0 +1,78 @@
+import { FC, useState } from "react";
+import { LxdNetworkAcl } from "types/network";
+import { queryKeys } from "util/queryKeys";
+import { updateNetworkAcl } from "api/networks";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  ConfirmationButton,
+  Icon,
+  useNotify,
+} from "@canonical/react-components";
+import { useToastNotification } from "context/toastNotificationProvider";
+
+interface Props {
+  acl: LxdNetworkAcl;
+  project: string;
+  index: number;
+  type: number;
+  onDelete: () => void;
+}
+
+const DeleteNetworkAclRuleBtn: FC<Props> = ({ acl, project, index, type, onDelete }) => {
+  const queryClient = useQueryClient();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const [isLoading, setLoading] = useState(false);
+
+  const handleDelete = () => {
+    onDelete();
+    setLoading(true);
+    acl[type].splice(index, 1);
+    updateNetworkAcl({ ...acl, etag: acl.etag }, project)
+      .then(() => {
+        void queryClient.invalidateQueries({
+          queryKey: [
+            queryKeys.projects,
+            project,
+            queryKeys.networkAcls,
+            acl.name,
+          ],
+        });
+        setLoading(false);
+        toastNotify.success(
+          <>
+            Network ACL rule deleted.
+          </>,
+        );
+      })
+      .catch((e) => {
+        notify.failure("Network ACL rule deletion failed", e);
+      })
+  };
+
+  return (
+    <ConfirmationButton
+      appearance="base"
+      onHoverText="Delete network ACL rule"
+      confirmationModalProps={{
+        title: "Confirm delete",
+        confirmButtonAppearance: "negative",
+        confirmButtonLabel: "Delete",
+        children: (
+          <p>
+            Are you sure you want to delete selected network ACL rule?<br />
+          </p>
+        ),
+        onConfirm: handleDelete,
+      }}
+      className="u-no-margin--bottom has-icon"
+      loading={isLoading}
+      shiftClickEnabled
+      showShiftClickHint
+    >
+      <Icon name="delete" />
+    </ConfirmationButton>
+  );
+};
+
+export default DeleteNetworkAclRuleBtn;

--- a/src/pages/networks/forms/NetworkAclForm.tsx
+++ b/src/pages/networks/forms/NetworkAclForm.tsx
@@ -1,0 +1,103 @@
+import { FC, useEffect } from "react";
+import { Col, Form, Input, Row, useNotify } from "@canonical/react-components";
+import { LxdNetworkAcl } from "types/network";
+import NetworkAclFormMenu, {
+  MAIN_CONFIGURATION,
+  YAML_CONFIGURATION,
+} from "pages/networks/forms/NetworkAclFormMenu";
+import { FormikProps } from "formik/dist/types";
+import { updateMaxHeight } from "util/updateMaxHeight";
+import useEventListener from "@use-it/event-listener";
+import YamlForm from "components/forms/YamlForm";
+import NetworkAclFormMain from "pages/networks/forms/NetworkAclFormMain";
+import { slugify } from "util/slugify";
+import { useDocs } from "context/useDocs";
+import { getHandledNetworkConfigKeys, getNetworkKey } from "util/networks";
+import YamlNotification from "components/forms/YamlNotification";
+import { ensureEditMode } from "util/instanceEdit";
+
+export interface NetworkAclFormValues {
+  readOnly: boolean;
+  isCreating: boolean;
+  name: string;
+  description?: string;
+  parent?: string;
+  yaml?: string;
+  entityType: "networkAcl";
+}
+
+export const toNetworkAcl = (values: NetworkAclFormValues): Partial<LxdNetworkAcl> => {
+
+  return {
+    name: values.name,
+    description: values.description,
+  };
+};
+
+interface Props {
+  formik: FormikProps<NetworkAclFormValues>;
+  getYaml: () => string;
+  project: string;
+  section: string;
+  setSection: (section: string) => void;
+  version?: number;
+}
+
+const NetworkAclForm: FC<Props> = ({
+  formik,
+  getYaml,
+  project,
+  section,
+  setSection,
+  version = 0,
+}) => {
+  const docBaseLink = useDocs();
+  const notify = useNotify();
+
+  const updateFormHeight = () => {
+    updateMaxHeight("form-contents", "p-bottom-controls");
+  };
+  useEffect(updateFormHeight, [notify.notification?.message, section]);
+  useEventListener("resize", updateFormHeight);
+
+  return (
+    <Form className="form network-form" onSubmit={formik.handleSubmit}>
+      {/* hidden submit to enable enter key in inputs */}
+      <Input type="submit" hidden value="Hidden input" />
+      {section !== slugify(YAML_CONFIGURATION) && (
+        <NetworkAclFormMenu
+          active={section}
+          setActive={setSection}
+          formik={formik}
+        />
+      )}
+      <Row className="form-contents" key={section}>
+        <Col size={12}>
+          {section === slugify(MAIN_CONFIGURATION) && (
+            <NetworkAclFormMain
+              formik={formik}
+              project={project}
+            />
+          )}
+          {section === slugify(YAML_CONFIGURATION) && (
+            <YamlForm
+              key={`yaml-form-${version}`}
+              yaml={getYaml()}
+              setYaml={(yaml) => {
+                ensureEditMode(formik);
+                void formik.setFieldValue("yaml", yaml);
+              }}
+            >
+              <YamlNotification
+                entity="network-acl"
+                href={`${docBaseLink}/explanation/networks/#managed-networks`}
+              />
+            </YamlForm>
+          )}
+        </Col>
+      </Row>
+    </Form>
+  );
+};
+
+export default NetworkAclForm;

--- a/src/pages/networks/forms/NetworkAclFormMain.tsx
+++ b/src/pages/networks/forms/NetworkAclFormMain.tsx
@@ -1,0 +1,56 @@
+import { FC, ReactNode } from "react";
+import { Col, Input, Row } from "@canonical/react-components";
+import { FormikProps } from "formik/dist/types";
+import { NetworkAclFormValues } from "pages/networks/forms/NetworkAclForm";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
+import ScrollableForm from "components/ScrollableForm";
+import { ensureEditMode } from "util/instanceEdit";
+
+interface Props {
+  formik: FormikProps<NetworkAclFormValues>;
+  project: string;
+}
+
+const NetworkAclFormMain: FC<Props> = ({ formik, project }) => {
+  const getFormProps = (id: "name" | "description") => {
+    return {
+      id: id,
+      name: id,
+      onBlur: formik.handleBlur,
+      onChange: (e: unknown) => {
+        ensureEditMode(formik);
+        formik.handleChange(e);
+      },
+      value: formik.values[id] ?? "",
+      error: formik.touched[id] ? (formik.errors[id] as ReactNode) : null,
+      placeholder: `Enter ${id.replaceAll("_", " ")}`,
+    };
+  };
+
+  return (
+    <ScrollableForm>
+      <Row>
+        <Col size={12}>
+          <Input
+            {...getFormProps("name")}
+            type="text"
+            label="Name"
+            required
+            disabled={formik.values.readOnly || !formik.values.isCreating}
+            help={
+              !formik.values.isCreating
+                ? "Click the name in the header to rename the network ACL"
+                : undefined
+            }
+          />
+          <AutoExpandingTextArea
+            {...getFormProps("description")}
+            label="Description"
+          />
+        </Col>
+      </Row>
+    </ScrollableForm>
+  );
+};
+
+export default NetworkAclFormMain;

--- a/src/pages/networks/forms/NetworkAclFormMenu.tsx
+++ b/src/pages/networks/forms/NetworkAclFormMenu.tsx
@@ -1,0 +1,41 @@
+import { FC, useEffect } from "react";
+import MenuItem from "components/forms/FormMenuItem";
+import { useNotify } from "@canonical/react-components";
+import { updateMaxHeight } from "util/updateMaxHeight";
+import useEventListener from "@use-it/event-listener";
+import { FormikProps } from "formik/dist/types";
+import { NetworkAclFormValues } from "pages/networks/forms/NetworkAclForm";
+
+export const MAIN_CONFIGURATION = "Main configuration";
+export const YAML_CONFIGURATION = "YAML configuration";
+
+interface Props {
+  active: string;
+  setActive: (val: string) => void;
+  formik: FormikProps<NetworkAclFormValues>;
+}
+
+const NetworkAclFormMenu: FC<Props> = ({ active, setActive, formik }) => {
+  const notify = useNotify();
+  const menuItemProps = {
+    active,
+    setActive,
+  };
+
+  const resize = () => {
+    updateMaxHeight("form-navigation", "p-bottom-controls");
+  };
+  useEffect(resize, [notify.notification?.message]);
+  useEventListener("resize", resize);
+  return (
+    <div className="p-side-navigation--accordion form-navigation">
+      <nav aria-label="Network form navigation">
+        <ul className="p-side-navigation__list">
+          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
+        </ul>
+      </nav>
+    </div>
+  );
+};
+
+export default NetworkAclFormMenu;

--- a/src/pages/networks/forms/NetworkAclRuleForm.tsx
+++ b/src/pages/networks/forms/NetworkAclRuleForm.tsx
@@ -1,0 +1,213 @@
+import { FC, useEffect, useRef } from "react";
+import {
+  Col,
+  Form,
+  Input,
+  Label,
+  Notification,
+  Row,
+  Select,
+  useNotify,
+} from "@canonical/react-components";
+import { FormikProps } from "formik/dist/types";
+import * as Yup from "yup";
+import { LxdNetworkAcl } from "types/network";
+import { updateMaxHeight } from "util/updateMaxHeight";
+import useEventListener from "@use-it/event-listener";
+import NotificationRow from "components/NotificationRow";
+import ScrollableForm from "components/ScrollableForm";
+
+export const toNetworkAclRule = (
+  values: NetworkAclRuleFormValues,
+): LxdNetworkAclRule => {
+  return {
+    action: values.action,
+    state: values.state,
+    description: values.description,
+    source: values.source,
+    destination: values.destination,
+    protocol: values.protocol,
+    source_port: values.sourcePort,
+    destination_port: values.destinationPort,
+    icmp_type: values.icmpType,
+    icmp_ode: values.icmpCode,
+  };
+};
+
+export const NetworkAclRuleSchema = Yup.object().shape({
+});
+
+export interface NetworkAclRuleFormValues {
+  readOnly: boolean;
+  isCreating: boolean;
+  action: string;
+  state: string;
+  description?: string;
+  source?: string;
+  destination?: string;
+  protocol?: string;
+  sourcePort?: string;
+  destinationPort?: string;
+  icmpType?: string;
+  icmpCode?: string;
+  yaml?: string;
+}
+
+interface Props {
+  formik: FormikProps<NetworkAclFormValues>;
+  acl?: LxdNetworkAcl;
+  showNotify: boolean;
+}
+
+const NetworkAclRuleForm: FC<Props> = ({ formik, acl, showNotify }) => {
+  const notify = useNotify();
+  const divNotifyRef = useRef<HTMLDivElement | null>(null);
+
+  const updateFormHeight = () => {
+    updateMaxHeight("form-contents", "p-bottom-controls");
+  };
+  useEffect(updateFormHeight, [notify.notification?.message]);
+  useEventListener("resize", updateFormHeight);
+  useEffect(() => {
+      divNotifyRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [showNotify]);
+
+  return (
+    <Form className="form network-forwards-form" onSubmit={formik.handleSubmit}>
+      <Row className="form-contents">
+        <Col size={12}>
+          <ScrollableForm>
+            {/* hidden submit to enable enter key in inputs */}
+            <Input type="submit" hidden value="Hidden input" />
+            <div ref={divNotifyRef}>
+              <Row className="p-form__group p-form-validation">
+                <NotificationRow />
+              </Row>
+            </div>
+            <Select
+              {...formik.getFieldProps("action")}
+              options={[
+                {
+                  label: "allow",
+                  value: "allow",
+                },
+                {
+                  label: "allow-stateless",
+                  value: "allow-stateless",
+                },
+                {
+                  label: "reject",
+                  value: "reject",
+                },
+                {
+                  label: "drop",
+                  value: "drop",
+                },
+              ]}
+              onChange={ formik.handleChange }
+              label="Action"
+              help="Action to take for matching traffic"
+              required
+              disabled={formik.values.readOnly || !formik.values.isCreating}
+            />
+            <Select
+              {...formik.getFieldProps("state")}
+              options={[
+                {
+                  label: "enabled",
+                  value: "enaled",
+                },
+                {
+                  label: "disabled",
+                  value: "disabled",
+                },
+                {
+                  label: "logged",
+                  value: "logged",
+                },
+              ]}
+              onChange={ formik.handleChange }
+              label="State"
+              help="State of the rule"
+              required
+              disabled={formik.values.readOnly || !formik.values.isCreating}
+            />
+            <Input
+              {...formik.getFieldProps("description")}
+              id="description"
+              type="text"
+              label="Description"
+              placeholder="Enter description"
+            />
+            <Input
+              {...formik.getFieldProps("source")}
+              id="source"
+              type="text"
+              label="Source"
+            />
+            <Input
+              {...formik.getFieldProps("destination")}
+              id="destination"
+              type="text"
+              label="Destination"
+            />
+            <Select
+              {...formik.getFieldProps("protocol")}
+              options={[
+                {
+                  label: "",
+                  value: "",
+                },
+                {
+                  label: "icmp4",
+                  value: "icmp4",
+                },
+                {
+                  label: "icmp6",
+                  value: "icmp6",
+                },
+                {
+                  label: "tcp",
+                  value: "tcp",
+                },
+                {
+                  label: "udp",
+                  value: "udp",
+                },
+              ]}
+              onChange={ formik.handleChange }
+              label="Protocol"
+              disabled={formik.values.readOnly || !formik.values.isCreating}
+            />
+            <Input
+              {...formik.getFieldProps("sourcePort")}
+              id="sourcePort"
+              type="text"
+              label="Source port"
+            />
+            <Input
+              {...formik.getFieldProps("destinationPort")}
+              id="destinationPort"
+              type="text"
+              label="Destination port"
+            />
+            <Input
+              {...formik.getFieldProps("icmpType")}
+              id="icmpType"
+              type="text"
+              label="ICMP type"
+            />
+            <Input
+              {...formik.getFieldProps("icmpCode")}
+              id="icmpCode"
+              type="text"
+              label="ICMP code"
+            />
+          </ScrollableForm>
+        </Col>
+      </Row>
+    </Form>
+  );
+};
+
+export default NetworkAclRuleForm;

--- a/src/sass/_network_acl.scss
+++ b/src/sass/_network_acl.scss
@@ -1,0 +1,6 @@
+.network-acl-rule-list {
+  .u-row:hover,
+  .u-row-selected {
+    background-color: $colors--light-theme--background-hover;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -94,6 +94,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "meter";
 @import "migrate_instance";
 @import "modified_actions";
+@import "network_acl";
 @import "network_detail_list";
 @import "network_detail_overview";
 @import "network_form";
@@ -320,6 +321,7 @@ body {
   border-top: none !important;
 }
 
+.network-acl-rules-table,
 .network-forwards-table {
   .actions {
     max-width: 8rem;

--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -120,3 +120,23 @@ export interface LxdNetworkForward {
   location?: string;
   ports: LxdNetworkForwardPort[];
 }
+
+export interface LxdNetworkAclRule {
+  action: string;
+  state: string;
+  description?: string;
+  source?: string;
+  destintion?: string;
+  protocol?: string;
+  source_port?: string;
+  destination_port?: string;
+  icmp_type?: string;
+  icmp_code?: string;
+}
+
+export interface LxdNetworkAcl {
+  name: string;
+  description?: string;
+  ingress?: LxdNetworkAclRule[];
+  egress?: LxdNetworkAclRule[];
+}

--- a/src/util/networkForm.tsx
+++ b/src/util/networkForm.tsx
@@ -1,9 +1,11 @@
 import {
   LxdNetwork,
+  LxdNetworkAcl,
   LxdNetworkBridgeDriver,
   LxdNetworkDnsMode,
 } from "types/network";
 import { NetworkFormValues } from "pages/networks/forms/NetworkForm";
+import { NetworkAclFormValues } from "pages/networks/forms/NetworkAclForm";
 import { getNetworkKey } from "util/networks";
 
 export const toNetworkFormValues = (network: LxdNetwork): NetworkFormValues => {
@@ -50,5 +52,15 @@ export const toNetworkFormValues = (network: LxdNetwork): NetworkFormValues => {
     parent: network.config.parent,
     entityType: "network",
     bareNetwork: network,
+  };
+};
+
+export const toNetworkAclFormValues = (acl: LxdNetworkAcl): NetworkAclFormValues => {
+  return {
+    readOnly: true,
+    isCreating: false,
+    name: acl.name,
+    description: acl.description,
+    entityType: "networkAcl",
   };
 };

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -12,6 +12,7 @@ export const queryKeys = {
   members: "members",
   metrics: "metrics",
   networks: "networks",
+  networkAcls: "networkAcls",
   operations: "operations",
   profiles: "profiles",
   projects: "projects",


### PR DESCRIPTION
This PR introduces support for managing network ACLs, allowing users to define, modify, and delete rules for controlling network traffic based on IP addresses, ports, and protocols.

<img src="https://github.com/user-attachments/assets/7628f5fa-1f2d-4c8f-a809-d243757083d6" alt="ACLs" width="400"/>
<img src="https://github.com/user-attachments/assets/bf5aad26-8170-4c5c-b115-8eaaaa773fbd" alt="ACL details" width="400"/>
<img src="https://github.com/user-attachments/assets/32b421fa-6c4d-46ae-9cf1-d85282fcd1fc" alt="rules" width="400"/>
