### PR TITLE
Enhanced Error Notifications in Terminal View

### DIFF
--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -22,7 +22,7 @@ import AttachIsoBtn from "pages/instances/actions/AttachIsoBtn";
 import NotificationRow from "components/NotificationRow";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useOperations } from "context/operationsProvider";
-import { getInstanceName, getProjectName } from "util/operations";
+import { getInstanceName, getProjectName, findOperation } from "util/operations";
 
 interface Props {
   instance: LxdInstance;
@@ -76,19 +76,9 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
 
   const { handleStart, isLoading } = useInstanceStart(instance);
 
-  const getOperation = (operation: LxdOperation, description: string) => {
-      const projectName = getProjectName(operation);
-      const instanceName = getInstanceName(operation);
-
-      if (projectName == instance.project && instanceName == instance.name && description == operation.description) {
-        return true;
-      }
-      return false;
-  };
-
   useEffect(() => {
     // Check if there are any relevant instance operations.
-    let restartOp = operations.find((operation) => {return getOperation(operation, "Restarting instance");})
+    let restartOp = findOperation(instance, operations, "Restarting instance");
 
     if (restartOp) {
       if (restartOp.status == "Success" && lastOp.current["restart"] != restartOp.created_at && attemptConnection) {
@@ -99,7 +89,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
       }
     }
 
-    let startOp = operations.find((operation) => {return getOperation(operation, "Starting instance");})
+    let startOp = findOperation(instance, operations, "Starting instance");
     if (startOp) {
       // Disconect console if start operation was detected.
       setAttemptConnection(false);
@@ -109,7 +99,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
       }
     }
 
-    let stopOp = operations.find((operation) => {return getOperation(operation, "Stopping instance");})
+    let stopOp = findOperation(instance, operations, "Stopping instance");
     if (stopOp) {
       // Disconect console if stop operation was detected.
       setAttemptConnection(false);

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -18,6 +18,12 @@ import {
   Icon,
   useNotify,
 } from "@canonical/react-components";
+import { useOperations } from "context/operationsProvider";
+import {
+  getInstanceName,
+  getProjectName,
+  findOperation,
+} from "util/operations";
 import NotificationRow from "components/NotificationRow";
 
 const XTERM_OPTIONS = {
@@ -59,7 +65,9 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
   const [payload, setPayload] = useState(defaultPayload);
   const [fitAddon] = useState<FitAddon>(new FitAddon());
   const [userInteracted, setUserInteracted] = useState(false);
+  const { operations, isFetching } = useOperations();
   const xtermRef = useRef<Terminal>(null);
+  const lastFailureOp = useRef(null);
 
   usePrompt({
     when: userInteracted,
@@ -118,7 +126,9 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
       if (1005 !== event.code) {
         notify.failure("Error", event.reason, getWsErrorMsg(event.code));
       }
+      data?.close();
       setControlWs(null);
+      setDataWs(null);
     };
 
     data.onopen = () => {
@@ -133,7 +143,9 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
       if (1005 !== event.code) {
         notify.failure("Error", event.reason, getWsErrorMsg(event.code));
       }
+      control?.close();
       setDataWs(null);
+      setControlWs(null);
       setUserInteracted(false);
     };
 
@@ -144,6 +156,18 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
 
     return [data, control];
   };
+
+  useEffect(() => {
+    // Check if there are any relevant instance operations.
+    let op = findOperation(instance, operations, "Executing command");
+
+    if (op) {
+      if (op.status == "Failure" && op.err != "" && (lastFailureOp.current == null || lastFailureOp.current.id != op.id)) {
+        notify.failure("Error", op.status_code, op.err);
+        lastFailureOp.current = op;
+      }
+    }
+  }, [operations]);
 
   useEffect(() => {
     xtermRef.current?.clear();

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -1,3 +1,4 @@
+import { LxdInstance } from "types/instance";
 import { LxdOperation } from "types/operation";
 
 export const getInstanceName = (operation?: LxdOperation): string => {
@@ -50,3 +51,15 @@ export const getProjectName = (operation: LxdOperation): string => {
       ?.split("&")[0] ?? "default"
   );
 };
+
+export const findOperation = (instance: LxdInstance, operations: LxdOperation[], operation_type: string) => {
+  return operations.find((operation) => {
+    const projectName = getProjectName(operation);
+    const instanceName = getInstanceName(operation);
+
+    if (projectName == instance.project && instanceName == instance.name && operation_type == operation.description) {
+      return true;
+    }
+    return false;
+  });
+}


### PR DESCRIPTION
This PR introduces more detailed error notifications from the `operation` object. Users will now receive clearer error messages whenever a failure is detected. A slight delay may occur before the notification is displayed, as we need to wait for the operation to complete before providing the error details.

![cmd_not_found](https://github.com/user-attachments/assets/fe3db458-c5d2-4032-8826-a076ea3ca5f1)

Fixes: #21 