### PR TITLE
Fix issue with listing instances when cluster member is down

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -169,7 +169,7 @@ const InstanceList: FC = () => {
         (q) =>
           item.name.toLowerCase().includes(q) ||
           item.description.toLowerCase().includes(q) ||
-          item.config["image.description"]?.toLowerCase().includes(q),
+          item.config?.["image.description"]?.toLowerCase().includes(q),
       )
     ) {
       return false;

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -91,7 +91,7 @@ export const getInstanceType = (
     (item) => item.value === instance.type,
   )?.label;
 
-  if (instance.config["volatile.container.oci"] === "true") {
+  if (instance.config?.["volatile.container.oci"] === "true") {
     return `${label} (App)`
   }
 


### PR DESCRIPTION
This PR adds a check to handle cases where the `config` property of an instance is `null`. This situation can occur when one of the cluster members is down, and the instance resides on the affected server.

Fixes: #28 