### PR TITLE
Check if state object is not null/undefined

### DIFF
--- a/src/pages/instances/InstanceOverviewMetrics.tsx
+++ b/src/pages/instances/InstanceOverviewMetrics.tsx
@@ -88,7 +88,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
             <tr className="metric-row">
               <th className="u-text--muted">CPU Time(s)</th>
               <td>
-                {state.cpu && state.cpu.usage > 0 ? (
+                {state && state.cpu && state.cpu.usage > 0 ? (
                   <div>
                     {humanCpuUsage(state.cpu.usage)}
                   </div>
@@ -100,7 +100,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
             <tr className="metric-row">
               <th className="u-text--muted">Memory</th>
               <td>
-                {state.memory ? (
+                {state && state.memory ? (
                   <div>
                     <Meter
                       percentage={


### PR DESCRIPTION
The `state` object can be `null` or `undefined` if the state endpoint responds with a status other than 200. This PR addresses and handles such scenarios gracefully.

Fixes: #34 