### PR TITLE
Show MAC address on instance overview page

### DIFF
--- a/src/pages/instances/InstanceMAC.tsx
+++ b/src/pages/instances/InstanceMAC.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react";
+import { getMACAddresses } from "util/networks";
+import { LxdInstance } from "types/instance";
+import ExpandableList from "components/ExpandableList";
+
+interface Props {
+  instance: LxdInstance;
+}
+
+const InstanceMAC: FC<Props> = ({ instance }) => {
+  const addresses = getMACAddresses(instance);
+  return addresses.length ? (
+    <ExpandableList
+      items={addresses.map((item) => (
+        <div
+          key={item.hwaddr}
+          className="u-truncate"
+          title={`MAC ${item.hwaddr} (${item.iface})`}
+        >
+          {item.hwaddr} ({item.iface})
+        </div>
+      ))}
+    />
+  ) : (
+    <>-</>
+  );
+};
+
+export default InstanceMAC;

--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -9,6 +9,7 @@ import InstanceOverviewProfiles from "./InstanceOverviewProfiles";
 import InstanceOverviewMetrics from "./InstanceOverviewMetrics";
 import InstancePreview from "./InstancePreview";
 import InstanceIps from "pages/instances/InstanceIps";
+import InstanceMAC from "pages/instances/InstanceMAC";
 import { useSettings } from "context/useSettings";
 import NotificationRow from "components/NotificationRow";
 import DeviceListTable from "components/DeviceListTable";
@@ -85,6 +86,12 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
                 <th className="u-text--muted">IPv6</th>
                 <td>
                   <InstanceIps instance={instance} family="inet6" />
+                </td>
+              </tr>
+              <tr>
+                <th className="u-text--muted">MAC address</th>
+                <td>
+                  <InstanceMAC instance={instance} />
                 </td>
               </tr>
               <tr>

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -17,6 +17,15 @@ export const getIpAddresses = (
     .filter((item) => item.family === family);
 };
 
+export const getMACAddresses = (
+  instance: LxdInstance,
+) => {
+  if (!instance.state?.network) return [];
+  return Object.entries(instance.state.network)
+    .filter(([key, _value]) => key !== "lo")
+    .map(([key, value]) => {return { iface: key, hwaddr: value.hwaddr }});
+};
+
 export const networkFormFieldToPayloadName: Record<
   string,
   keyof LxdNetworkConfig


### PR DESCRIPTION
This PR enables displaying the MAC address in the instance overview page.

![mac](https://github.com/user-attachments/assets/6297182e-b4d4-470c-92ed-3157a6b378b1)



Closes: #37