### PR TITLE
Add support for target selection when creating or moving custom storage volumes

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -313,6 +313,38 @@ export const createStorageVolume = (
   });
 };
 
+export const copyCustomVolumeToTarget = (
+  project: string,
+  volume: Partial<LxdStorageVolume>,
+  target: string,
+): Promise<LxdOperationResponse> => {
+  return new Promise((resolve, reject) => {
+    fetch(
+      `/1.0/storage-pools/${volume.pool}/volumes?project=${project}&target=${target}`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: volume.name,
+          type: "custom",
+          content_type: volume.content_type,
+          source: {
+            name: volume.name,
+            type: "copy",
+            pool: volume.pool,
+            volume_only: false,
+            refresh: false,
+            refresh_exclude_older: false,
+            location: volume.location,
+          },
+        }),
+      },
+    )
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
 export const updateStorageVolume = (
   pool: string,
   project: string,
@@ -341,10 +373,12 @@ export const deleteStorageVolume = (
   volume: string,
   pool: string,
   project: string,
+  target?: string,
 ): Promise<void> => {
+  const targetParam = target ? `&target=${target}` : "";
   return new Promise((resolve, reject) => {
     fetch(
-      `/1.0/storage-pools/${pool}/volumes/custom/${volume}?project=${project}`,
+      `/1.0/storage-pools/${pool}/volumes/custom/${volume}?project=${project}${targetParam}`,
       {
         method: "DELETE",
       },

--- a/src/pages/storage/CustomVolumeClusterMemberMigration.tsx
+++ b/src/pages/storage/CustomVolumeClusterMemberMigration.tsx
@@ -1,0 +1,68 @@
+import { FC } from "react";
+import { ActionButton, Button } from "@canonical/react-components";
+import { LxdStorageVolume } from "types/storage";
+import ClusterMemberSelectTable from "../cluster/ClusterMemberSelectTable";
+
+interface Props {
+  storageVolume: LxdStorageVolume;
+  targetMember: string;
+  migrate: (
+    targetPool: string | undefined,
+    targetMember: string | undefined,
+  ) => void;
+  close: () => void;
+  onSelect: (value: string) => void;
+}
+
+const CustomVolumeClusterMemberMigration: FC<Props> = ({
+  storageVolume,
+  targetMember,
+  migrate,
+  close,
+  onSelect,
+}) => {
+  const summary = (
+    <div className="migrate-instance-summary">
+      <p>
+        This will migrate custom volume <strong>{storageVolume.name}</strong> to
+        cluster member <b>{targetMember}</b>.
+      </p>
+    </div>
+  );
+
+  return (
+    <>
+      {targetMember && summary}
+      {!targetMember && (
+        <ClusterMemberSelectTable
+          onSelect={onSelect}
+          disableMember={{
+            name: storageVolume.location,
+            reason: "Custom volume already on this member",
+          }}
+        />
+      )}
+      <footer id="migrate-instance-actions" className="p-modal__footer">
+        <Button
+          className="u-no-margin--bottom"
+          type="button"
+          aria-label="cancel migrate"
+          appearance="base"
+          onClick={close}
+        >
+          Cancel
+        </Button>
+        <ActionButton
+          appearance="positive"
+          className="u-no-margin--bottom"
+          onClick={() => migrate(undefined, targetMember)}
+          disabled={!targetMember}
+        >
+          Migrate
+        </ActionButton>
+      </footer>
+    </>
+  );
+};
+
+export default CustomVolumeClusterMemberMigration;

--- a/src/pages/storage/CustomVolumeStoragePoolMigration.tsx
+++ b/src/pages/storage/CustomVolumeStoragePoolMigration.tsx
@@ -1,0 +1,70 @@
+import { FC } from "react";
+import { ActionButton, Button } from "@canonical/react-components";
+import StoragePoolSelectTable from "../storage/StoragePoolSelectTable";
+import { LxdStorageVolume } from "types/storage";
+
+interface Props {
+  storageVolume: LxdStorageVolume;
+  targetPool: string;
+  onSelect: (pool: string) => void;
+  close: () => void;
+  migrate: (
+    targetPool: string | undefined,
+    targetMember: string | undefined,
+  ) => void;
+}
+
+const CustomVolumeStoragePoolMigration: FC<Props> = ({
+  storageVolume,
+  targetPool,
+  onSelect,
+  close,
+  migrate,
+}) => {
+  const summary = (
+    <div className="migrate-instance-summary">
+      <p>
+        This will migrate the storage volume{" "}
+        <strong>{storageVolume.name}</strong> to pool <b>{targetPool}</b>.
+      </p>
+    </div>
+  );
+
+  return (
+    <>
+      {targetPool && summary}
+      {!targetPool && (
+        <StoragePoolSelectTable
+          onSelect={onSelect}
+          disablePool={{
+            name: storageVolume.pool,
+            reason: "Storage volume already in this pool",
+          }}
+        />
+      )}
+      {targetPool && (
+        <footer id="migrate-instance-actions" className="p-modal__footer">
+          <Button
+            className="u-no-margin--bottom"
+            type="button"
+            aria-label="cancel migrate"
+            appearance="base"
+            onClick={close}
+          >
+            Cancel
+          </Button>
+          <ActionButton
+            appearance="positive"
+            className="u-no-margin--bottom"
+            onClick={() => migrate(targetPool, undefined)}
+            disabled={!targetPool}
+          >
+            Migrate
+          </ActionButton>
+        </footer>
+      )}
+    </>
+  );
+};
+
+export default CustomVolumeStoragePoolMigration;

--- a/src/pages/storage/MigrateVolumeModal.tsx
+++ b/src/pages/storage/MigrateVolumeModal.tsx
@@ -1,16 +1,39 @@
 import { FC, KeyboardEvent, useState } from "react";
-import { ActionButton, Button, Modal } from "@canonical/react-components";
+import { Modal } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { fetchStoragePool } from "api/storage-pools";
+import { useSettings } from "context/useSettings";
+import { isClusteredServer } from "util/settings";
+import BackLink from "components/BackLink";
+import FormLink from "components/FormLink";
+import Loader from "components/Loader";
+import CustomVolumeClusterMemberMigration from "./CustomVolumeClusterMemberMigration";
+import CustomVolumeStoragePoolMigration from "./CustomVolumeStoragePoolMigration";
 import { LxdStorageVolume } from "types/storage";
-import StoragePoolSelectTable from "./StoragePoolSelectTable";
+import { isLocalPool } from "util/storagePool";
+import { queryKeys } from "util/queryKeys";
 
 interface Props {
   close: () => void;
-  migrate: (target: string) => void;
+  migrate: (
+    targetPool: string | undefined,
+    targetMember: string | undefined,
+  ) => void;
   storageVolume: LxdStorageVolume;
 }
 
 const MigrateVolumeModal: FC<Props> = ({ close, migrate, storageVolume }) => {
-  const [selectedPool, setSelectedPool] = useState("");
+  const { data: settings } = useSettings();
+  const { data: pool, isLoading } = useQuery({
+    queryKey: [queryKeys.storage, storageVolume.pool],
+    queryFn: () => fetchStoragePool(storageVolume.pool),
+  });
+
+  const allowChooseMigrationType =
+    isClusteredServer(settings) && isLocalPool(pool, settings);
+
+  const [type, setType] = useState("");
+  const [target, setTarget] = useState("");
 
   const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
     if (e.key === "Escape") {
@@ -18,26 +41,46 @@ const MigrateVolumeModal: FC<Props> = ({ close, migrate, storageVolume }) => {
     }
   };
 
-  const handleCancel = () => {
-    if (selectedPool) {
-      setSelectedPool("");
+  const handleGoBack = () => {
+    // if incus is not clustered, we close the modal
+    if (!allowChooseMigrationType) {
+      close();
       return;
     }
 
-    close();
+    // if target is set, we are on the confirmation stage
+    if (target) {
+      setTarget("");
+      return;
+    }
+
+    // if type is set, we are on migration target selection stage
+    if (type) {
+      setType("");
+      return;
+    }
   };
 
-  const modalTitle = selectedPool
-    ? "Confirm migration"
-    : `Choose storage pool for volume ${storageVolume.name}`;
+  const selectStepTitle = (
+    <>
+      Choose {type} for custom volume <strong>{storageVolume.name}</strong>
+    </>
+  );
 
-  const summary = (
-    <div className="migrate-instance-summary">
-      <p>
-        This will migrate volume <strong>{storageVolume.name}</strong> to
-        storage pool <b>{selectedPool}</b>.
-      </p>
-    </div>
+  const modalTitle = !type ? (
+    "Choose migration method"
+  ) : (
+    <>
+      {allowChooseMigrationType && (
+        <BackLink
+          title={target ? "Confirm migration" : selectStepTitle}
+          onClick={handleGoBack}
+          linkText={target ? `Choose ${type}` : "Choose migration method"}
+        />
+      )}
+      {!allowChooseMigrationType &&
+        (target ? "Confirm migration" : selectStepTitle)}
+    </>
   );
 
   return (
@@ -45,38 +88,42 @@ const MigrateVolumeModal: FC<Props> = ({ close, migrate, storageVolume }) => {
       close={close}
       className="migrate-instance-modal"
       title={modalTitle}
-      buttonRow={
-        <div id="migrate-instance-actions">
-          <Button
-            className="u-no-margin--bottom"
-            type="button"
-            aria-label="cancel migrate"
-            appearance="base"
-            onClick={handleCancel}
-          >
-            Cancel
-          </Button>
-          <ActionButton
-            appearance="positive"
-            className="u-no-margin--bottom"
-            onClick={() => migrate(selectedPool)}
-            disabled={!selectedPool}
-          >
-            Migrate
-          </ActionButton>
-        </div>
-      }
       onKeyDown={handleEscKey}
     >
-      {selectedPool ? (
-        summary
-      ) : (
-        <StoragePoolSelectTable
-          onSelect={setSelectedPool}
-          disablePool={{
-            name: storageVolume.pool,
-            reason: "Volume is already in this pool",
-          }}
+      {isLoading && <Loader />}
+      {!isLoading && allowChooseMigrationType && !type && (
+        <div className="choose-migration-type">
+          <FormLink
+            icon="cluster-host"
+            title="Migrate custom volume to a different cluster member"
+            onClick={() => setType("cluster member")}
+          />
+          <FormLink
+            icon="switcher-dashboard"
+            title="Migrate custom volume to a different pool"
+            onClick={() => setType("storage pool")}
+          />
+        </div>
+      )}
+
+      {!isLoading && type === "cluster member" && (
+        <CustomVolumeClusterMemberMigration
+          storageVolume={storageVolume}
+          targetMember={target}
+          onSelect={setTarget}
+          close={handleGoBack}
+          migrate={migrate}
+        />
+      )}
+
+      {/* If incus is not clustered, we always show storage pool migration table */}
+      {!isLoading && (type === "storage pool" || !allowChooseMigrationType) && (
+        <CustomVolumeStoragePoolMigration
+          storageVolume={storageVolume}
+          targetPool={target}
+          onSelect={setTarget}
+          close={handleGoBack}
+          migrate={migrate}
         />
       )}
     </Modal>

--- a/src/pages/storage/forms/CreateStorageVolume.tsx
+++ b/src/pages/storage/forms/CreateStorageVolume.tsx
@@ -58,7 +58,7 @@ const CreateStorageVolume: FC = () => {
     validationSchema: StorageVolumeSchema,
     onSubmit: (values) => {
       const volume = volumeFormToPayload(values, project);
-      createStorageVolume(values.pool, project, volume)
+      createStorageVolume(values.pool, project, volume, values.clusterMember)
         .then(() => {
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.storage],

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -9,6 +9,7 @@ import ConfigurationTable from "components/ConfigurationTable";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import { optionTrueFalse } from "util/instanceOptions";
+import ClusterMemberSelector from "pages/cluster/ClusterMemberSelector";
 import StoragePoolSelector from "pages/storage/StoragePoolSelector";
 import ScrollableForm from "components/ScrollableForm";
 import { ensureEditMode } from "util/instanceEdit";
@@ -16,9 +17,18 @@ import { ensureEditMode } from "util/instanceEdit";
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
   poolError?: string;
+  showClusterMember: boolean;
 }
 
-const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
+const StorageVolumeFormMain: FC<Props> = ({
+  formik,
+  poolError,
+  showClusterMember,
+}) => {
+  const setMember = formik.values.isCreating
+    ? (member: string) => void formik.setFieldValue("clusterMember", member)
+    : undefined;
+
   return (
     <ScrollableForm>
       <Row>
@@ -98,6 +108,16 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
             }}
             disabled={!formik.values.isCreating}
           />
+          {showClusterMember && (
+            <ClusterMemberSelector
+              {...getFormProps(formik, "clusterMember")}
+              id="clusterMember"
+              label="Cluster member"
+              value={formik.values.clusterMember}
+              setMember={setMember}
+              disabled={!formik.values.isCreating}
+            />
+          )}
         </Col>
       </Row>
       {formik.values.content_type === "filesystem" && (

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -1,6 +1,8 @@
 import { AbortControllerState, checkDuplicateName } from "util/helpers";
 import { AnyObject, TestFunction } from "yup";
 import { LxdConfigOptionsKeys } from "types/config";
+import { LxdSettings } from "types/server";
+import { LxdStoragePool } from "types/storage";
 import { FormikProps } from "formik";
 import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
 import { powerFlex } from "util/storageOptions";
@@ -93,4 +95,18 @@ export const isPowerflexIncomplete = (
       !formik.values.powerflex_gateway ||
       !formik.values.powerflex_user_password)
   );
+};
+
+export const isLocalPool = (
+  pool: LxdStoragePool | undefined,
+  settings: LxdSettings | undefined,
+) => {
+  const driverDetails = settings?.environment?.storage_supported_drivers.find(
+    (driver) => driver.Name === pool?.driver,
+  );
+
+  if (!driverDetails) {
+    return false;
+  }
+  return !driverDetails.Remote;
 };

--- a/src/util/storageVolumeEdit.tsx
+++ b/src/util/storageVolumeEdit.tsx
@@ -11,6 +11,7 @@ export const getStorageVolumeEditValues = (
     size: volume.config.size ?? "GiB",
     content_type: volume.content_type,
     volumeType: volume.type,
+    clusterMember: volume.location,
     security_shifted: volume.config["security.shifted"],
     security_unmapped: volume.config["security.unmapped"],
     snapshots_expiry: volume.config["snapshots.expiry"],


### PR DESCRIPTION
- Added a selection widget for choosing a member during custom volume creation when the server is clustered, and the pool is not remote
- Added a selection window during migration to choose the migration type (pool or cluster member)

## Screenshots
<img src="https://github.com/user-attachments/assets/8b383691-585a-4771-8e01-0903a736ea73" width="300" />
<img src="https://github.com/user-attachments/assets/0ebdef0f-fe5e-4240-887f-8ebad42349da" width="300" />
<img src="https://github.com/user-attachments/assets/627072d7-b066-4d5d-a9e1-06862027e360" width="300" />

