### PR TITLE
Add field for cluster member when adding/editing network forwards

### DIFF
--- a/src/api/network-forwards.tsx
+++ b/src/api/network-forwards.tsx
@@ -36,8 +36,9 @@ export const createNetworkForward = (
   forward: Partial<LxdNetworkForward>,
   project: string,
 ): Promise<void> => {
+  const target = forward.location ? `&target=${forward.location}` : "";
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/networks/${network}/forwards?project=${project}`, {
+    fetch(`/1.0/networks/${network}/forwards?project=${project}${target}`, {
       method: "POST",
       body: JSON.stringify(forward),
     })
@@ -52,9 +53,10 @@ export const updateNetworkForward = (
   forward: Partial<LxdNetworkForward>,
   project: string,
 ): Promise<void> => {
+  const target = forward.location ? `&target=${forward.location}` : "";
   return new Promise((resolve, reject) => {
     fetch(
-      `/1.0/networks/${network}/forwards/${forward.listen_address}?project=${project}`,
+      `/1.0/networks/${network}/forwards/${forward.listen_address}?project=${project}${target}`,
       {
         method: "PUT",
         body: JSON.stringify(forward),
@@ -71,9 +73,10 @@ export const deleteNetworkForward = (
   forward: LxdNetworkForward,
   project: string,
 ): Promise<void> => {
+  const target = forward.location ? `&target=${forward.location}` : "";
   return new Promise((resolve, reject) => {
     fetch(
-      `/1.0/networks/${network.name}/forwards/${forward.listen_address}?project=${project}`,
+      `/1.0/networks/${network.name}/forwards/${forward.listen_address}?project=${project}${target}`,
       {
         method: "DELETE",
       },

--- a/src/pages/networks/EditNetworkForward.tsx
+++ b/src/pages/networks/EditNetworkForward.tsx
@@ -70,6 +70,7 @@ const EditNetworkForward: FC = () => {
           targetAddress: port.target_address,
           targetPort: port.target_port,
         })) ?? [],
+      location: forward?.location,
     },
     enableReinitialize: true,
     validationSchema: NetworkForwardSchema,


### PR DESCRIPTION
This change adds a field to select the cluster member when creating a network forward. When editing, the field is pre-filled but not editable. This ensures the correct member is passed to the API, avoiding errors when managing network forwards in clustered environments.

**Screenshots**

<img src="https://github.com/user-attachments/assets/5cd37795-754e-4cea-be66-916e96362757" width="400" />
<img src="https://github.com/user-attachments/assets/02d20b2e-d732-496c-a82c-c73557215c11" width="400" />

Fixes: #52
