### PR TITLE
Update StoragePoolSelector.tsx

### DIFF
--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -37,7 +37,7 @@ const StoragePoolSelector: FC<Props> = ({
   });
 
   const supportedStorageDrivers = getSupportedStorageDrivers(settings);
-  const poolsWithSupportedDriver = pools.filter((pool) =>
+  const poolsWithSupportedDriver = pools?.filter((pool) =>
     supportedStorageDrivers.has(pool.driver),
   );
 


### PR DESCRIPTION
Fix https://github.com/zabbly/incus-ui-canonical/issues/57#issuecomment-2848858376
```
index-BTX30BGB.js:41 TypeError: Cannot read properties of null (reading 'filter')
    at w (StoragePoolSelector-CKTl-q9P.js:1:977)
```

## Done

- [List of work items including drive-bys]

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

[if relevant, include a screenshot or screen capture]