### PR TITLE
Handle null response from storage-pools API by treating it as an empty array

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -32,7 +32,9 @@ export const fetchStoragePools = (): Promise<LxdStoragePool[]> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/storage-pools?recursion=1`)
       .then(handleResponse)
-      .then((data: LxdApiResponse<LxdStoragePool[]>) => resolve(data.metadata))
+      .then((data: LxdApiResponse<LxdStoragePool[]>) =>
+        resolve(data.metadata ?? []),
+      )
       .catch(reject);
   });
 };

--- a/src/pages/instances/forms/UploadInstanceBackupFileForm.tsx
+++ b/src/pages/instances/forms/UploadInstanceBackupFileForm.tsx
@@ -142,6 +142,7 @@ const UploadInstanceBackupFileForm: FC<Props> = ({
         project?.name || "",
         instanceNameAbort,
       ).optional(),
+      pool: Yup.string().required(),
     }),
     onSubmit: handleUpload,
   });

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -158,7 +158,7 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
         <ActionButton
           appearance="positive"
           loading={isLoading}
-          disabled={!file}
+          disabled={!file || !pool}
           className="u-no-margin--bottom"
           onClick={importFile}
         >


### PR DESCRIPTION
1. Graceful handling of null response from the GET /1.0/storage-pools API endpoint.
2. Improved form behavior when no storage pools are available.

Closes: #57 #63