### PR TITLE
Check array length before calling setArch

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -100,7 +100,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     .sort();
   const variantAll = [...new Set(images.map((item) => item.variant))].sort();
 
-  if (!isLoading && !archAll.includes(arch)) {
+  if (!isLoading && !archAll.includes(arch) && archAll.length > 0) {
     setArch(archAll[0]);
   }
 


### PR DESCRIPTION
When `archAll` is empty, `archAll[0]` is `undefined`. Since it's not a valid
architecture, the condition checking for it always passes, causing
`setArch` to be called repeatedly in an infinite loop.

Closes: #61
