### PR TITLE
Allow selecting un-managed bridges

### DIFF
--- a/src/pages/projects/forms/NetworkSelector.tsx
+++ b/src/pages/projects/forms/NetworkSelector.tsx
@@ -2,6 +2,7 @@ import { Select } from "@canonical/react-components";
 import type { SelectProps } from "@canonical/react-components";
 import type { FC } from "react";
 import { useNetworks } from "context/useNetworks";
+import { bridgeType } from "util/networks";
 
 interface Props {
   value: string;
@@ -21,10 +22,12 @@ const NetworkSelector: FC<Props & SelectProps> = ({
 }) => {
   const { data: networks = [] } = useNetworks(project);
 
-  const managedNetworks = networks.filter((network) => network.managed);
+  const filteredNetworks = networks.filter(
+    (network) => network.managed || network.type == bridgeType,
+  );
 
   const getNetworkOptions = () => {
-    const options = managedNetworks.map((network) => {
+    const options = filteredNetworks.map((network) => {
       return {
         label: network.name,
         value: network.name,

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -97,6 +97,21 @@ export const formDeviceToPayload = (devices: FormDevice[]) => {
           [name]: item.bare,
         };
       }
+      if (item.type === "nic") {
+        if (item.parent && item.parent != "") {
+          delete item.network;
+          return {
+            ...obj,
+            [name]: item,
+          };
+        }
+        delete item.parent;
+        delete item.nictype;
+        return {
+          ...obj,
+          [name]: item,
+        };
+      }
       if (item.type === "disk") {
         const { bare, ...rest } = item;
         item = { ...bare, ...rest };
@@ -118,7 +133,8 @@ export const parseDevices = (devices: LxdDevices): FormDevice[] => {
     const isCustomNetwork =
       item.type === "nic" &&
       Object.keys(item).some(
-        (key) => !["type", "name", "network"].includes(key),
+        (key) =>
+          !["type", "name", "network", "parent", "nictype"].includes(key),
       );
 
     if (isCustomNetwork) {
@@ -139,6 +155,15 @@ export const parseDevices = (devices: LxdDevices): FormDevice[] => {
 
     switch (item.type) {
       case "nic":
+        if (item.parent && item.parent != "") {
+          return {
+            name: key,
+            parent: item.parent,
+            nictype: item.nictype,
+            type: "nic",
+          };
+        }
+
         return {
           name: key,
           network: item.network,


### PR DESCRIPTION
This change allows selecting un-managed bridges when picking networks from the drop-down list.

Closes: #82