### PR TITLE
Fix several duplicate imports caused by rebase issues.

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -1,5 +1,4 @@
 import {
-  continueOrFinish,
   handleBlobResponse,
   handleEtagResponse,
   handleResponse,

--- a/src/pages/storage/forms/StorageVolumeForm.tsx
+++ b/src/pages/storage/forms/StorageVolumeForm.tsx
@@ -1,7 +1,6 @@
 import type { FC, ReactNode } from "react";
 import { useEffect } from "react";
 import { Col, Form, Input, Row, useNotify } from "@canonical/react-components";
-import { useSettings } from "context/useSettings";
 import { useParams } from "react-router-dom";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "util/useEventListener";


### PR DESCRIPTION
Commit b3039f4 (Add instance preview to overview view) added a duplicate
declaration of continueOrFinish to the imports in src/api/instances.tsx.

Commit 4340705 (Add support for target selection when creating or moving
custom storage volumes) added a duplicate declaration of useSettings to the
imports in src/pages/storage/forms/StorageVolumeForm.tsx.

These cause the UI to crash and have been removed.

Resolves: #84

