### PR TITLE
Add additional keyboard entries to the graphical console shortcuts.

### DIFF
--- a/src/lib/spice/src/inputs.js
+++ b/src/lib/spice/src/inputs.js
@@ -206,32 +206,18 @@ function send_key(sc, keyCode)
     sc.inputs.send_msg(msg);
 }
 
-function sendCtrlAltDel(sc)
+function sendKey(sc, code, modifiers = [])
 {
-    if (sc && sc.inputs && sc.inputs.state === "ready"){
-        update_modifier(true, KeyNames.KEY_LCtrl, sc);
-        update_modifier(true, KeyNames.KEY_Alt, sc);
-        send_key(sc, KeyNames.KEY_KP_Decimal);
-        if(Ctrl_state == false) update_modifier(false, KeyNames.KEY_LCtrl, sc);
-        if(Alt_state == false) update_modifier(false, KeyNames.KEY_Alt, sc);
-    }
-}
-
-function sendAltF4(sc)
-{
-    if (sc && sc.inputs && sc.inputs.state === "ready"){
-        update_modifier(true, KeyNames.KEY_Alt, sc);
-        send_key(sc, KeyNames.KEY_F4);
-        if(Alt_state == false) update_modifier(false, KeyNames.KEY_Alt, sc);
-    }
-}
-
-function sendAltTab(sc)
-{
-    if (sc && sc.inputs && sc.inputs.state === "ready"){
-        update_modifier(true, KeyNames.KEY_Alt, sc);
-        send_key(sc, KeyNames.KEY_Tab);
-        if(Alt_state == false) update_modifier(false, KeyNames.KEY_Alt, sc);
+    if (sc && sc.inputs && sc.inputs.state === "ready" && code) {
+        modifiers.forEach(m => {
+            update_modifier(true, m, sc);
+        });
+        send_key(sc, code);
+        modifiers.forEach(m => {
+            if (get_modifier_state(m) == false) {
+                update_modifier(false, m, sc);
+            }
+        });
     }
 }
 
@@ -252,6 +238,21 @@ function update_modifier(state, code, sc)
     }
 
     sc.inputs.send_msg(msg);
+}
+
+function get_modifier_state(m)
+{
+    if (m === KeyNames.KEY_ShiftL || m === KeyNames.KEY_ShiftR) {
+        return Shift_state;
+    } else if (m === KeyNames.KEY_LCtrl || m === KeyNames.KEY_RCtrl) {
+        return Ctrl_state;
+    } else if (m === KeyNames.KEY_Alt) {
+        return Alt_state;
+    } else if (m === 0xE0B5) {
+        return Meta_state;
+    }
+
+    return false;
 }
 
 function check_and_update_modifiers(e, code, sc)
@@ -319,7 +320,5 @@ export {
   handle_mousewheel,
   handle_keydown,
   handle_keyup,
-  sendCtrlAltDel,
-  sendAltTab,
-  sendAltF4,
+  sendKey,
 };

--- a/src/lib/spice/src/main.js
+++ b/src/lib/spice/src/main.js
@@ -24,7 +24,7 @@ import { SpiceCursorConn } from './cursor.js';
 import { SpiceConn } from './spiceconn.js';
 import { DEBUG } from './utils.js';
 import { SpiceFileXferTask } from './filexfer.js';
-import { SpiceInputsConn, sendCtrlAltDel } from './inputs.js';
+import { SpiceInputsConn } from './inputs.js';
 import { SpiceDisplayConn } from './display.js';
 import { SpicePlaybackConn } from './playback.js';
 import { SpicePortConn } from './port.js';
@@ -515,5 +515,4 @@ export {
   handle_file_drop,
   resize_helper,
   handle_resize,
-  sendCtrlAltDel,
 };

--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -15,7 +15,8 @@ import type { LxdInstance } from "types/instance";
 import { LxdOperation } from "types/operation";
 import InstanceTextConsole from "./InstanceTextConsole";
 import { useInstanceStart } from "util/instanceStart";
-import { sendAltF4, sendAltTab, sendCtrlAltDel } from "lib/spice/src/inputs.js";
+import { sendKey } from "lib/spice/src/inputs.js";
+import { KeyNames } from "lib/spice/src/atKeynames.js";
 import AttachIsoBtn from "pages/instances/actions/AttachIsoBtn";
 import NotificationRow from "components/NotificationRow";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
@@ -182,19 +183,43 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
                   {
                     children: "Send Ctrl + Alt + Del",
                     onClick: () => {
-                      sendCtrlAltDel(window.spice_connection);
+                      sendKey(window.spice_connection, KeyNames.KEY_KP_Decimal, [ KeyNames.KEY_LCtrl, KeyNames.KEY_Alt ]);
                     },
                   },
                   {
                     children: "Send Alt + TAB",
                     onClick: () => {
-                      sendAltTab(window.spice_connection);
+                      sendKey(window.spice_connection, KeyNames.KEY_Tab, [ KeyNames.KEY_Alt ]);
                     },
                   },
                   {
                     children: "Send Alt + F4",
                     onClick: () => {
-                      sendAltF4(window.spice_connection);
+                      sendKey(window.spice_connection, KeyNames.KEY_F4, [ KeyNames.KEY_Alt]);
+                    },
+                  },
+                  {
+                    children: "Send Ctrl + Alt + F1",
+                    onClick: () => {
+                      sendKey(window.spice_connection, KeyNames.KEY_F1, [ KeyNames.KEY_LCtrl, KeyNames.KEY_Alt ]);
+                    },
+                  },
+                  {
+                    children: "Send Ctrl + Alt + F2",
+                    onClick: () => {
+                      sendKey(window.spice_connection, KeyNames.KEY_F2, [ KeyNames.KEY_LCtrl, KeyNames.KEY_Alt]);
+                    },
+                  },
+                  {
+                    children: "Send Ctrl + Alt + F3",
+                    onClick: () => {
+                      sendKey(window.spice_connection, KeyNames.KEY_F3, [ KeyNames.KEY_LCtrl, KeyNames.KEY_Alt]);
+                    },
+                  },
+                  {
+                    children: "Send Ctrl + Alt + F4",
+                    onClick: () => {
+                      sendKey(window.spice_connection, KeyNames.KEY_F4, [ KeyNames.KEY_LCtrl, KeyNames.KEY_Alt]);
                     },
                   },
                 ]}

--- a/src/types/spice-inputs.d.ts
+++ b/src/types/spice-inputs.d.ts
@@ -1,7 +1,5 @@
 declare module "lib/spice/src/inputs.js" {
   import type * as SpiceHtml5 from "lib/spice/src/main";
 
-  export function sendAltF4(connection?: SpiceHtml5.SpiceMainConn): void;
-  export function sendAltTab(connection?: SpiceHtml5.SpiceMainConn): void;
-  export function sendCtrlAltDel(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendKey(connection?: SpiceHtml5.SpiceMainConn, keycode?: number, modifiers?: number[]): void;
 }


### PR DESCRIPTION
* Added CTRL+ALT+F1,2,3,4 to allow switching virtual terminals in Linux VMs.

* Refactored spice key handling to replace the existing individual send*
functions with a single sendKey function that takes the keycode and a list
of modifiers.

