### PR TITLE
Fix missing current buckets in ui and no storage pool in create bucke…

### DIFF
--- a/src/components/forms/DiskSizeSelector.tsx
+++ b/src/components/forms/DiskSizeSelector.tsx
@@ -54,7 +54,11 @@ const DiskSizeSelector: FC<Props> = ({
           step="Any"
           placeholder="Enter value"
           onChange={(e) => {
-            setMemoryLimit(e.target.value + limit.unit);
+            if (e.target.value) {
+              setMemoryLimit(e.target.value + limit.unit);
+            } else {
+              setMemoryLimit("");
+            }
           }}
           value={value?.match(/^\d/) ? limit.value : ""}
           disabled={disabled}

--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -4,7 +4,6 @@ import type { CustomSelectOption } from "@canonical/react-components";
 import { CustomSelect, useNotify } from "@canonical/react-components";
 import Loader from "components/Loader";
 import type { Props as SelectProps } from "@canonical/react-components/dist/components/Select/Select";
-import { cephObject } from "util/storageOptions";
 import StoragePoolOptionLabel from "./StoragePoolOptionLabel";
 import StoragePoolOptionHeader from "./StoragePoolOptionHeader";
 import { useStoragePools } from "context/useStoragePools";
@@ -20,13 +19,13 @@ const StoragePoolSelector: FC<Props> = ({
   value,
   setValue,
   selectProps,
-  invalidDrivers = [cephObject],
+  invalidDrivers,
 }) => {
   const notify = useNotify();
   const { data: pools = [], error, isLoading } = useStoragePools();
 
   const poolsToUse = pools.filter((pool) => {
-    return !invalidDrivers.includes(pool.driver);
+    return !invalidDrivers?.includes(pool.driver);
   });
 
   useEffect(() => {

--- a/src/pages/storage/forms/StorageBucketForm.tsx
+++ b/src/pages/storage/forms/StorageBucketForm.tsx
@@ -6,7 +6,6 @@ import StoragePoolSelector from "../StoragePoolSelector";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
 import type { LxdStorageBucket } from "types/storage";
-import { cephObject, storageDriverLabels } from "util/storageOptions";
 
 export interface StorageBucketFormValues {
   name: string;
@@ -60,16 +59,14 @@ const StorageBucketForm: FC<Props> = ({ formik, bucket }) => {
       <StoragePoolSelector
         value={formik.values.pool}
         setValue={(value) => void formik.setFieldValue("pool", value)}
-        invalidDrivers={Object.keys(storageDriverLabels).filter((key) => {
-          return key !== cephObject;
-        })}
+        invalidDrivers={[]}
         selectProps={{
           id: "bucket-create-pool",
           label: "Storage pool",
           disabled: !!bucketEditRestriction || isEditing,
           help: isEditing
             ? "Storage bucket pool can't be changed"
-            : "Pool must have a Ceph Object driver",
+            : "",
         }}
       />
       <DiskSizeSelector

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -25,7 +25,7 @@ export const storageDriverLabels: { [key: string]: string } = {
   [lvmClusterDriver]: "LVM Cluster",
 };
 
-const bucketCompatibleDrivers = [cephObject];
+const bucketCompatibleDrivers = [dirDriver, btrfsDriver, lvmDriver, zfsDriver];
 
 export const isBucketCompatibleDriver = (driver: string): boolean => {
   return bucketCompatibleDrivers.includes(driver);


### PR DESCRIPTION
## Done

- [storage > bucket now lists the current buckets]
- [bucket create form now shows the storage pools with supported driver]

## Screenshots
### before 
<img width="1006" height="514" alt="Screenshot_20251122_173915" src="https://github.com/user-attachments/assets/a52d59c7-6ae7-4e16-93ed-382c1cd5c7cf" />
<img width="1207" height="479" alt="Screenshot_20251122_173851" src="https://github.com/user-attachments/assets/eae103f3-fa32-4ef5-8855-d7ab9bfd0457" />

### after
<img width="1443" height="541" alt="new" src="https://github.com/user-attachments/assets/873699d1-aa06-43d3-91bc-5e6d1c8a77ce" />
<img width="962" height="491" alt="new2" src="https://github.com/user-attachments/assets/74a0419c-8aa6-47b8-917c-2202e450beca" />
