### PR TITLE
Fix adding devices to an instance

### DIFF
--- a/src/components/forms/OtherDeviceForm.tsx
+++ b/src/components/forms/OtherDeviceForm.tsx
@@ -172,11 +172,11 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
     }
     const device = formik.values.devices[index];
 
-    const type = device.type === "usb" ? "unix-usb" : device.type;
-    const id = `device-${type}` as "server";
+    const type = ["unix-char", "unix-block"].includes(device.type) ? "unix-char-block" : device.type;
+    const id = `${type}` as "server";
 
-    const rawOptions = configOptions?.configs[id];
-    const configFields = rawOptions ? toConfigFields(rawOptions) : [];
+    const rawOptions = configOptions?.configs.devices[id];
+    const configFields = rawOptions ? toConfigFields({"device" : rawOptions}) : [];
 
     customRows.push(
       getConfigurationRowBase({


### PR DESCRIPTION
There are differences between LXD and Incus in the `configuration.json` definition. In Incus devices are located in the `configs.devices` section, while in LXD they appear directly under `configs`. Additionally, in LXD device entries use the `devices-` prefix and have an additional child node called `device-conf`.

Closes: #99