### PR TITLE
Add 'target' parameter to /os/1.0

### DIFF
--- a/src/api/os.tsx
+++ b/src/api/os.tsx
@@ -17,8 +17,8 @@ const prepareOSURL = (url: string, target: string) => {
   return result;
 };
 
-export const fetchOS = async (): Promise<IncusOSSettings> => {
-  return fetch("/os/1.0")
+export const fetchOS = async (target: string): Promise<IncusOSSettings> => {
+  return fetch(prepareOSURL("/os/1.0", target))
     .then(handleResponse)
     .then((data: LxdApiResponse<IncusOSSettings>) => {
       return data.metadata;

--- a/src/context/useIncusOS.tsx
+++ b/src/context/useIncusOS.tsx
@@ -4,9 +4,9 @@ import { fetchOS } from "api/os";
 import type { IncusOSSettings } from "types/os";
 import { queryKeys } from "util/queryKeys";
 
-export const useIncusOS = (): UseQueryResult<IncusOSSettings> => {
+export const useIncusOS = (target: string): UseQueryResult<IncusOSSettings> => {
   return useQuery({
-    queryKey: [queryKeys.os],
-    queryFn: async () => fetchOS(),
+    queryKey: [queryKeys.os, target],
+    queryFn: async () => fetchOS(target),
   });
 };

--- a/src/pages/os/OSOverview.tsx
+++ b/src/pages/os/OSOverview.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 const OSOverview: FC<Props> = ({ target }) => {
   const notify = useNotify();
-  const { data: incusOSData, error, isLoading } = useIncusOS();
+  const { data: incusOSData, error, isLoading } = useIncusOS(target);
 
   const { data: systemUpdate } = useQuery({
     queryKey: [queryKeys.osUpdate, target],


### PR DESCRIPTION
Fixes an issue with fetching the version for a specific server.