### PR TITLE
Pass valid filter to useInstances

### DIFF
--- a/src/pages/instances/forms/CopyInstanceForm.tsx
+++ b/src/pages/instances/forms/CopyInstanceForm.tsx
@@ -32,6 +32,7 @@ import { useProjectEntitlements } from "util/entitlements/projects";
 import { useStoragePools } from "context/useStoragePools";
 import { useIsClustered } from "context/useIsClustered";
 import { isRootDisk } from "util/instanceValidation";
+import { encodeServerFilters } from "util/instanceFilter";
 
 interface Props {
   instance: LxdInstance;
@@ -60,7 +61,7 @@ const CopyInstanceForm: FC<Props> = ({ instance, close }) => {
   const { data: storagePools = [], isLoading: storagePoolsLoading } =
     useStoragePools();
 
-  const { data: instances = [] } = useInstances(instance.project);
+  const { data: instances = [] } = useInstances(instance.project, encodeServerFilters([""]));
 
   const notifySuccess = (
     name: string,

--- a/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
@@ -26,6 +26,7 @@ import { useProjectEntitlements } from "util/entitlements/projects";
 import { useStoragePools } from "context/useStoragePools";
 import { useIsClustered } from "context/useIsClustered";
 import { truncateEntityName } from "util/helpers";
+import { encodeServerFilters } from "util/instanceFilter";
 
 interface Props {
   instance: LxdInstance;
@@ -96,7 +97,7 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
   const { data: storagePools = [], isLoading: storagePoolsLoading } =
     useStoragePools();
 
-  const { data: instances = [] } = useInstances(instance.project);
+  const { data: instances = [] } = useInstances(instance.project, encodeServerFilters([""]));
 
   const notifySuccess = (
     name: string,

--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -6,6 +6,7 @@ import classnames from "classnames";
 import { linkForVolumeDetail, hasVolumeDetailPage } from "util/storageVolume";
 import { useInstances } from "context/useInstances";
 import { useImagesInProject } from "context/useImages";
+import { encodeServerFilters } from "util/instanceFilter";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -23,7 +24,7 @@ const StorageVolumeNameLink: FC<Props> = ({
 
   const isInstance =
     volume.type === "container" || volume.type === "virtual-machine";
-  const { data: instances = [] } = useInstances(volume.project);
+  const { data: instances = [] } = useInstances(volume.project, encodeServerFilters([""]));
   const instance =
     isInstance && instances.find((instance) => instance.name === volume.name);
 


### PR DESCRIPTION
## Done

- Passes a valid filter object to the `useInstances` function called from the `StorageVolumes` page.

## QA

**Before the code change:**

Browse to the `Storage > Volumes` page in the Incus UI.
The following is in network requests with `filter=undefined`:

<img width="1040" height="126" alt="image" src="https://github.com/user-attachments/assets/3bca934c-e2cf-4e6a-96e1-8ca065f5ebea" />

Browse to  the `Profiles` page and then to the `Instances` page.
Due to the previous call having an invalid filter, the following is displayed on the `Instances` page:
<img width="877" height="197" alt="image" src="https://github.com/user-attachments/assets/45d9d968-0762-47d9-aa34-8ece16af4a42" />

This pops up frequently when navigating around the UI.

**After the code change:**

Browsing to `Storage > Volumes` result in a correct filter being passed to `useInstances`:

<img width="884" height="29" alt="image" src="https://github.com/user-attachments/assets/a90da829-3aaf-4d13-a96b-53cfa279910d" />
