### PR TITLE
Hide some UI components if not allowed access to the 'default' project

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -39,6 +39,7 @@ import { queryKeys } from "util/queryKeys";
 import DocLink from "components/DocLink";
 import AuthenticationTlsStepper from "./AuthenticationTlsStepper";
 import { ALL_PROJECTS } from "util/projects";
+import { isAdmin } from "util/permissions";
 
 const initialiseOpenNavMenus = (location: Location) => {
   const openPermissions = location.pathname.includes("/permissions/");
@@ -105,6 +106,7 @@ const Navigation: FC = () => {
   const navigate = useNavigate();
   const isClustered = useIsClustered();
   const isOidc = authMethod === AUTH_METHOD.OIDC;
+  const hasAdminPermissions = isAdmin();
 
   const { data: isRunningIncusOS = false } = useQuery({
     queryKey: [queryKeys.osCheck],
@@ -664,7 +666,7 @@ const Navigation: FC = () => {
                       </SideNavigationItem>
                     </>
                   )}
-                  {isAuthenticated && isRunningIncusOS && (
+                  {isAuthenticated && isRunningIncusOS && hasAdminPermissions && (
                     <>
                       <hr
                         className={classnames("navigation-hr", {

--- a/src/pages/projects/NavigationProjectSelector.tsx
+++ b/src/pages/projects/NavigationProjectSelector.tsx
@@ -12,6 +12,7 @@ import { defaultFirst } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 import { useProjects } from "context/useProjects";
 import { useServerEntitlements } from "util/entitlements/server";
+import { isAdmin } from "util/permissions";
 
 interface Props {
   activeProject: string;
@@ -85,9 +86,9 @@ const NavigationProjectSelector: FC<Props> = ({
             }}
             className="p-contextual-menu__link"
             hasIcon
-            disabled={!canCreateProjects()}
+            disabled={!isAdmin()}
             title={
-              canCreateProjects()
+              isAdmin()
                 ? ""
                 : "You do not have permission to create projects"
             }

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -22,11 +22,13 @@ import { StoragePoolClusterMember } from "./StoragePoolClusterMember";
 import { useIsClustered } from "context/useIsClustered";
 import DocLink from "components/DocLink";
 import { ROOT_PATH } from "util/rootPath";
+import { isAdmin } from "util/permissions";
 
 const StoragePools: FC = () => {
   const notify = useNotify();
   const { project } = useParams<{ project: string }>();
   const isClustered = useIsClustered();
+  const canCreatePool = isAdmin();
 
   if (!project) {
     return <>Missing project</>;
@@ -161,10 +163,12 @@ const StoragePools: FC = () => {
             Learn more about storage pools, volumes and buckets
           </DocLink>
         </p>
-        <CreateStoragePoolBtn
-          project={project}
-          className="empty-state-button"
-        />
+        {canCreatePool && (
+          <CreateStoragePoolBtn
+            project={project}
+            className="empty-state-button"
+          />
+        )}
       </EmptyState>
     );
 
@@ -184,10 +188,12 @@ const StoragePools: FC = () => {
             </PageHeader.Title>
           </PageHeader.Left>
           <PageHeader.BaseActions>
-            <CreateStoragePoolBtn
-              project={project}
-              className="u-float-right u-no-margin--bottom"
-            />
+            {canCreatePool && (
+              <CreateStoragePoolBtn
+                project={project}
+                className="u-float-right u-no-margin--bottom"
+              />
+            )}
           </PageHeader.BaseActions>
         </PageHeader>
       }

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -1,3 +1,4 @@
+import { useProjects } from "context/useProjects";
 import type { LxdIdentity, LxdPermission } from "types/permissions";
 import type { LxdImage } from "types/image";
 import type { ResourceDetail } from "./resourceDetails";
@@ -378,4 +379,16 @@ export const getResourceOptionColumns = (type: string) => {
   };
 
   return resourceOptionColumns[type] ?? resourceOptionColumns.default;
+};
+
+// isAdmin checks whether the user has admin privileges.
+// A user is considered an admin if their default project is set.
+export const isAdmin = (): boolean => {
+  const { data: projects = [], isLoading: projectsLoading } = useProjects();
+
+  if (projectsLoading) {
+    return false;
+  }
+
+  return projects.some((p) => p.name === "default");
 };


### PR DESCRIPTION
- Hide the "Create project" option
- Hide the "Create" button on the pool list
- Hide the "OS" tab

Closes: #149