### PR TITLE
Remove snapshots and size columns from volumes view

### DIFF
--- a/src/api/storage-volumes.tsx
+++ b/src/api/storage-volumes.tsx
@@ -25,7 +25,7 @@ export const fetchStorageVolumes = async (
   isFineGrained: boolean | null,
 ): Promise<LxdStorageVolume[]> => {
   const params = new URLSearchParams();
-  params.set("recursion", "2");
+  params.set("recursion", "1");
   params.set("project", project);
   addEntitlements(params, isFineGrained, volumeEntitlements);
 

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -22,7 +22,6 @@ import StorageVolumesFilter, {
   QUERY,
   VOLUME_TYPE,
 } from "pages/storage/StorageVolumesFilter";
-import StorageVolumeSize from "pages/storage/StorageVolumeSize";
 import {
   figureCollapsedScreen,
   getVolumeId,
@@ -38,8 +37,6 @@ import {
   CONTENT_TYPE_COL,
   NAME_COL,
   POOL_COL,
-  SIZE_COL,
-  SNAPSHOTS_COL,
   TYPE_COL,
   USED_BY_COL,
 } from "util/storageVolumeTable";
@@ -158,36 +155,11 @@ const StorageVolumes: FC = () => {
           },
         ]),
     {
-      content: SIZE_COL,
-      className: "u-align--right size",
-      style: { width: COLUMN_WIDTHS[SIZE_COL] },
-    },
-    {
-      content: isSmallScreen ? (
-        <>
-          {USED_BY_COL}
-          <br />
-          <div className="header-second-row">{SNAPSHOTS_COL}</div>
-        </>
-      ) : (
-        USED_BY_COL
-      ),
-      sortKey: isSmallScreen ? "snapshots" : "usedBy",
+      content: USED_BY_COL,
+      sortKey: "usedBy",
       className: "u-align--right used_by",
-      style: {
-        width: COLUMN_WIDTHS[isSmallScreen ? SNAPSHOTS_COL : USED_BY_COL],
-      },
+      style: { width: COLUMN_WIDTHS[USED_BY_COL] },
     },
-    ...(isSmallScreen
-      ? []
-      : [
-          {
-            className: "u-align--right",
-            content: SNAPSHOTS_COL,
-            sortKey: "snapshots",
-            style: { width: COLUMN_WIDTHS[SNAPSHOTS_COL] },
-          },
-        ]),
     {
       content: "",
       className: "actions u-align--right",
@@ -234,7 +206,6 @@ const StorageVolumes: FC = () => {
     const id = getVolumeId(volume);
     const volumeType = renderVolumeType(volume);
     const contentType = renderContentType(volume);
-    const snapshotCount = volume?.snapshots?.length ?? 0;
     const canSelect = hasVolumeDetailPage(volume);
 
     return {
@@ -305,39 +276,12 @@ const StorageVolumes: FC = () => {
               },
             ]),
         {
-          content: <StorageVolumeSize volume={volume} />,
-          role: "cell",
-          "aria-label": SIZE_COL,
-          className: "u-align--right size",
-          style: { width: COLUMN_WIDTHS[SIZE_COL] },
-        },
-        {
           className: "u-align--right used_by",
-          content: (
-            <>
-              {volume.used_by?.length ?? 0}
-              {isSmallScreen && (
-                <div className="u-text--muted">{snapshotCount}</div>
-              )}
-            </>
-          ),
+          content: volume.used_by?.length ?? 0,
           role: "cell",
           "aria-label": USED_BY_COL,
-          style: {
-            width: COLUMN_WIDTHS[isSmallScreen ? SNAPSHOTS_COL : USED_BY_COL],
-          },
+          style: { width: COLUMN_WIDTHS[USED_BY_COL] },
         },
-        ...(isSmallScreen
-          ? []
-          : [
-              {
-                className: "u-align--right",
-                content: snapshotCount,
-                role: "cell",
-                "aria-label": SNAPSHOTS_COL,
-                style: { width: COLUMN_WIDTHS[SNAPSHOTS_COL] },
-              },
-            ]),
         {
           className: "actions u-align--right",
           content: hasVolumeDetailPage(volume) ? (
@@ -370,7 +314,6 @@ const StorageVolumes: FC = () => {
         contentType: contentType,
         type: volumeType,
         usedBy: volume.used_by?.length ?? 0,
-        snapshots: snapshotCount,
       },
     };
   });


### PR DESCRIPTION
Any broken link between an instance and a storage volume caused the storage volume list to error out. The view fetched snapshots for each volume, which required `recursion=2` in the query and that deeper recursion is where the failure surfaced.
The `Size` column was also expensive to compute for every volume.